### PR TITLE
[feat]: 식단 조회 API 구현

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/entity/Board.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/entity/Board.java
@@ -12,6 +12,7 @@ import lombok.*;
 @Entity
 public class Board {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String title;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/converter/CafeteriaConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/converter/CafeteriaConverter.java
@@ -14,6 +14,7 @@ public class CafeteriaConverter {
     }
     public static CafeteriaCreateResponseDTO toCafeteriaResponse(Cafeteria cafeteria){
         return CafeteriaCreateResponseDTO.builder()
+                .cafeteriaId(cafeteria.getId())
                 .build();
 
     }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/dto/response/CafeteriaCreateResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/dto/response/CafeteriaCreateResponseDTO.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class CafeteriaCreateResponseDTO {
 
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/dto/response/CafeteriaCreateResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/dto/response/CafeteriaCreateResponseDTO.java
@@ -3,10 +3,13 @@ package fiveguys.Tom.Cafeteria.Server.domain.cafeteria.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
+@Getter
 public class CafeteriaCreateResponseDTO {
-
+    private Long cafeteriaId;
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/entity/Cafeteria.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/entity/Cafeteria.java
@@ -2,6 +2,8 @@ package fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity;
 
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.*;
 
@@ -15,6 +17,7 @@ import java.time.LocalTime;
 @Entity
 public class Cafeteria {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/service/CafeteriaCommandServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/service/CafeteriaCommandServiceImpl.java
@@ -12,6 +12,6 @@ public class CafeteriaCommandServiceImpl implements CafeteriaCommandService {
 
     @Override
     public Cafeteria enroll(Cafeteria cafeteria) {
-        return null;
+        return cafeteriaRepository.save(cafeteria);
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
@@ -4,6 +4,7 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.controller;
 import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietCreateDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietCreateResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.service.DietCommandService;
@@ -21,9 +22,9 @@ public class AdminDietController {
 
     private final DietCommandService dietCommandService;
     @PostMapping("/")
-    public ApiResponse<DietResponseDTO> getDiet(@RequestBody DietCreateDTO dietCreateDTO){
+    public ApiResponse<DietCreateResponseDTO> getDiet(@RequestBody DietCreateDTO dietCreateDTO){
         List<Long> menuList = dietCreateDTO.getMenuIdList();
         Diet diet = dietCommandService.createDiet(DietConverter.toDiet(dietCreateDTO), menuList);
-        return ApiResponse.onSuccess(DietConverter.toDietResponseDTO(diet));
+        return ApiResponse.onSuccess(DietConverter.toDietCreateResponseDTO(diet));
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
@@ -2,25 +2,41 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.controller;
 
 
 import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietCreateDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.MenuDiet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.service.DietQueryService;
+import fiveguys.Tom.Cafeteria.Server.domain.menu.converter.MenuConverter;
+import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseListDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.DayOfWeek;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/diet")
+@RequestMapping("/diets")
 public class DietController {
     private final DietQueryService dietQueryService;
-    @GetMapping("/{day}")
-    public ApiResponse<Menu> getDiet(@PathVariable(name = "day") DayOfWeek dayOfWeek){
-        Diet diet = dietQueryService.getDiet(dayOfWeek);
+    @GetMapping("/{cafeteria}/{day}")
+    public ApiResponse<DietResponseDTO> getDiet(@PathVariable(name = "day") DayOfWeek dayOfWeek,
+                                                @PathVariable(name = "cafeteria")Cafeteria cafeteria,
+                                                @RequestParam(name = "meals")Meals meals){
+        Diet diet = dietQueryService.getDiet(cafeteria, dayOfWeek, meals);
         List<MenuDiet> menuDietList = diet.getMenuDietList();
+        List<Menu> menuList = menuDietList.stream()
+                .map(MenuDiet::getMenu)
+                .collect(Collectors.toList());
+        DietResponseDTO dietResponseDTO = DietConverter.toDietResponseDTO(diet, MenuConverter.toMenuResponseListDTO(menuList));
+        return ApiResponse.onSuccess(dietResponseDTO);
     }
+//    @GetMapping("")
+//    public ApiResponse<>
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
@@ -3,6 +3,7 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.controller;
 
 import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.service.CafeteriaQueryService;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietCreateDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
@@ -13,6 +14,7 @@ import fiveguys.Tom.Cafeteria.Server.domain.diet.service.DietQueryService;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.converter.MenuConverter;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseListDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,10 +27,14 @@ import java.util.stream.Collectors;
 @RequestMapping("/diets")
 public class DietController {
     private final DietQueryService dietQueryService;
-    @GetMapping("/{cafeteria}/{day}")
+    private final CafeteriaQueryService cafeteriaQueryService;
+
+    @Operation(summary = "식단 조회 API", description = "요일, 식당, 식때를 요청인자로 받아 해당 식단의 id, 이미지, 메뉴명 리스트를 반환함,")
+    @GetMapping("/{cafeteriaId}/{day}")
     public ApiResponse<DietResponseDTO> getDiet(@PathVariable(name = "day") DayOfWeek dayOfWeek,
-                                                @PathVariable(name = "cafeteria")Cafeteria cafeteria,
+                                                @PathVariable(name = "cafeteriaId")Long cafeteriaId,
                                                 @RequestParam(name = "meals")Meals meals){
+        Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
         Diet diet = dietQueryService.getDiet(cafeteria, dayOfWeek, meals);
         List<MenuDiet> menuDietList = diet.getMenuDietList();
         List<Menu> menuList = menuDietList.stream()

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
@@ -2,8 +2,10 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.converter;
 
 
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietCreateDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietCreateResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
+import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseListDTO;
 
 public class DietConverter {
     public static Diet toDiet(DietCreateDTO dietCreateDTO){
@@ -14,9 +16,16 @@ public class DietConverter {
         return diet;
     }
 
-    public static DietResponseDTO toDietResponseDTO(Diet diet){
+    public static DietResponseDTO toDietResponseDTO(Diet diet, MenuResponseListDTO menuResponseListDTO){
         return DietResponseDTO.builder()
-                .id(diet.getId())
+                .menuResponseListDTO(menuResponseListDTO)
+                //.imageUri()
+                .build();
+    }
+    public static DietCreateResponseDTO toDietCreateResponseDTO(Diet diet){
+        return DietCreateResponseDTO.builder()
+                .dietId(diet.getId())
+                .cafeteriaId(diet.getCafeteria().getId())
                 .build();
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietCreateDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietCreateDTO.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.util.List;
 
 @Getter

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietCreateResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietCreateResponseDTO.java
@@ -1,0 +1,13 @@
+package fiveguys.Tom.Cafeteria.Server.domain.diet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class DietCreateResponseDTO {
+    private Long dietId;
+    private Long cafeteriaId;
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietResponseDTO.java
@@ -2,6 +2,7 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.dto;
 
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
+import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseListDTO;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,9 +16,8 @@ import java.time.DayOfWeek;
 @NoArgsConstructor
 public class DietResponseDTO {
     private Long id;
-//    private Meals meals;
-//    private DayOfWeek dayOfWeek; // 나중에 과거의 식단까지 볼 수 있도록 확장하면 날짜로 수정할 예정
-//    private String imageUri; //이미지 테이블 만들어야 함
+    private String imageUri; //이미지 테이블 만들어야 함
+    private MenuResponseListDTO menuResponseListDTO;
 //
 //    private Cafeteria cafeteria;
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/Diet.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/Diet.java
@@ -16,6 +16,7 @@ import java.util.List;
 @Entity
 public class Diet {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/MenuDiet.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/MenuDiet.java
@@ -14,6 +14,7 @@ import lombok.*;
 public class MenuDiet {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @JoinColumn(name = "menu_id")

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepository.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepository.java
@@ -1,11 +1,15 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.repository;
 
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.DayOfWeek;
+import java.util.List;
 import java.util.Optional;
 
 public interface DietRepository extends JpaRepository<Diet, Long> {
     public Optional<Diet> findByDayOfWeek(DayOfWeek dayOfWeek);
+    Optional<Diet> findByDayOfWeekAndCafeteriaAndMeals(DayOfWeek dayOfWeek, Cafeteria cafeteria, Meals meals);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryService.java
@@ -1,6 +1,8 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.service;
 
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -8,5 +10,7 @@ import java.util.List;
 
 public interface DietQueryService {
     public Diet getDiet(DayOfWeek dayOfWeek);
+
+    public Diet getDiet(Cafeteria cafeteria, DayOfWeek dayOfWeek, Meals meals);
     public List<Diet> getDietListOfWeek();
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryServiceImpl.java
@@ -1,7 +1,9 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.service;
 
 import fiveguys.Tom.Cafeteria.Server.apiPayload.code.status.ErrorStatus;
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.repository.DietRepository;
 import fiveguys.Tom.Cafeteria.Server.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,13 @@ public class DietQueryServiceImpl implements DietQueryService{
     @Override
     public Diet getDiet(DayOfWeek dayOfWeek) {
         Diet diet = dietRepository.findByDayOfWeek(dayOfWeek)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.DIET_NOT_FOUND));
+        return diet;
+    }
+
+    @Override
+    public Diet getDiet(Cafeteria cafeteria, DayOfWeek dayOfWeek, Meals meals) {
+        Diet diet = dietRepository.findByDayOfWeekAndCafeteriaAndMeals(dayOfWeek, cafeteria, meals)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.DIET_NOT_FOUND));
         return diet;
     }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/converter/MenuConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/converter/MenuConverter.java
@@ -1,0 +1,20 @@
+package fiveguys.Tom.Cafeteria.Server.domain.menu.converter;
+
+import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseListDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
+
+import java.util.List;
+
+public class MenuConverter {
+    public static MenuResponseDTO toMenuResponseDTO(Menu menu){
+        return MenuResponseDTO.builder()
+                .name(menu.getName())
+                .build();
+    }
+    public static MenuResponseListDTO toMenuResponseListDTO(List<Menu> menuResponseDTOList){
+        return MenuResponseListDTO.builder()
+                .menuResponseDTOList(menuResponseDTOList)
+                .build();
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/dto/MenuResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/dto/MenuResponseDTO.java
@@ -1,0 +1,15 @@
+package fiveguys.Tom.Cafeteria.Server.domain.menu.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MenuResponseDTO {
+    private String name;
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/dto/MenuResponseListDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/dto/MenuResponseListDTO.java
@@ -1,0 +1,17 @@
+package fiveguys.Tom.Cafeteria.Server.domain.menu.dto;
+
+import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class MenuResponseListDTO {
+    private List<Menu> menuResponseDTOList;
+
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/Menu.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/Menu.java
@@ -11,6 +11,7 @@ import lombok.*;
 @Entity
 public class Menu {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/MenuCategory.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/MenuCategory.java
@@ -1,6 +1,8 @@
 package fiveguys.Tom.Cafeteria.Server.domain.menu.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.*;
 
@@ -12,6 +14,7 @@ import lombok.*;
 @Entity
 public class MenuCategory {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/User.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/User.java
@@ -1,10 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server.domain.user.entity;
 
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
@@ -15,6 +12,7 @@ import lombok.*;
 @Entity
 public class User{
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
     password: ${DEV_DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3 

## 📝작업 내용

> 식단 조회 API 구현, 식당 등록 API 수정 및 테스트, 엔티티 ID 생성 전략 추가, jpa ddl-auto 설정 바꾸어 RDS에 JPA 엔티티 반영

