### PR TITLE
[feat/19]: 카카오 소셜 로그인 구현

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/TomCafeteriaServerApplication.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/TomCafeteriaServerApplication.java
@@ -1,9 +1,16 @@
 package fiveguys.Tom.Cafeteria.Server;
 
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.config.FeignConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableFeignClients(defaultConfiguration = FeignConfig.class)
+@EnableJpaAuditing
+@EnableScheduling
 public class TomCafeteriaServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/controller/LoginController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/controller/LoginController.java
@@ -1,0 +1,88 @@
+package fiveguys.Tom.Cafeteria.Server.auth.controller;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
+import fiveguys.Tom.Cafeteria.Server.auth.converter.LoginConverter;
+import fiveguys.Tom.Cafeteria.Server.auth.dto.LoginRequestDTO;
+import fiveguys.Tom.Cafeteria.Server.auth.dto.LoginResponseDTO;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao.dto.KakaoResponseDTO;
+import fiveguys.Tom.Cafeteria.Server.auth.jwt.JwtToken;
+import fiveguys.Tom.Cafeteria.Server.auth.jwt.service.JwtUtil;
+import fiveguys.Tom.Cafeteria.Server.auth.jwt.service.TokenProvider;
+import fiveguys.Tom.Cafeteria.Server.auth.service.KakoLoginService;
+import fiveguys.Tom.Cafeteria.Server.domain.user.UserConverter;
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
+import fiveguys.Tom.Cafeteria.Server.domain.user.service.UserCommandService;
+import fiveguys.Tom.Cafeteria.Server.domain.user.service.UserQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class LoginController {
+    private final KakoLoginService kakoLoginService;
+    private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+    private final TokenProvider tokenProvider;
+    private final JwtUtil jwtUtil;
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+
+
+    /*
+  테스트용 API, CORS 때문에 직접 호출하지 않고 redirect
+   */
+    @GetMapping("/oauth2/authorize/kakao")
+    public String login(){
+        String toRedirectUri = UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", kakaoClientId)
+                .queryParam("redirect_uri", redirectUri)
+                .toUriString();
+        return "redirect:" + toRedirectUri;
+    }
+
+    @Operation(summary = "카카오 소셜 토큰 검증 API",description = "추가정보와 ID토큰을 받으면 ID토큰을 검증하고 통과 시" +
+            "서버에서 발급한 토큰을 받습니다. 회원가입을 하지 않은 사용자의 경우 회원가입을 시킵니다.")
+    @ResponseBody
+    @PostMapping("/oauth2/kakao/token/validate")
+    public ApiResponse<LoginResponseDTO.LoginDTO> validateKakoToken(@RequestBody @Valid LoginRequestDTO.KakaoTokenValidateDTO requestDTO)  {
+        // identity 토큰 검증
+        // kakaoLoginService.validate(requestDTO.getIdentityToken());
+        // ok -> 유저 정보 가져오기
+        KakaoResponseDTO.UserInfoResponseDTO userInfo;
+        userInfo = kakoLoginService.getUserInfo(requestDTO.getAccessToken());
+        // 유저 정보에 DB 조회하고 정보 있으면 응답만, 없으면 저장까지, 추가정보 입력 여부에 따라서 응답 다르게
+        String socialId = userInfo.getSocialId();
+        User user;
+        if( userQueryService.isExistBySocialId(socialId)){
+            user = userQueryService.getUserBySocialId(socialId);
+        }
+        else{
+            user = UserConverter.toUser(userInfo);//, requestDTO.getAdditionalInfo());
+            user = userCommandService.create(user);
+        }
+        // 응답본문에 토큰 추가
+        JwtToken token = jwtUtil.generateToken(String.valueOf(user.getId()));
+        return ApiResponse.onSuccess(LoginConverter.toLoginDTO(token.getAccessToken(), token.getRefreshToken()));
+    }
+    /*
+    테스트용 API
+     */
+//    @GetMapping("/oauth2/login/kakao")
+//    public ResponseEntity<String> getAccessToken(@RequestParam(name = "code") String code){
+//        TokenResponse tokenResponse = kakaoLoginService.getAccessTokenByCode(code);
+//        return ResponseEntity.ok("accessToken="+ tokenResponse.getAccessToken() +
+//                "\n\nidToken=" + tokenResponse.getIdToken());
+//    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/controller/LoginController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/controller/LoginController.java
@@ -1,16 +1,16 @@
 package fiveguys.Tom.Cafeteria.Server.auth.controller;
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
 import fiveguys.Tom.Cafeteria.Server.auth.converter.LoginConverter;
 import fiveguys.Tom.Cafeteria.Server.auth.dto.LoginRequestDTO;
 import fiveguys.Tom.Cafeteria.Server.auth.dto.LoginResponseDTO;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.TokenResponse;
 import fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao.dto.KakaoResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.auth.jwt.JwtToken;
 import fiveguys.Tom.Cafeteria.Server.auth.jwt.service.JwtUtil;
 import fiveguys.Tom.Cafeteria.Server.auth.jwt.service.TokenProvider;
-import fiveguys.Tom.Cafeteria.Server.auth.service.KakoLoginService;
+import fiveguys.Tom.Cafeteria.Server.auth.service.KakaoLoginService;
 import fiveguys.Tom.Cafeteria.Server.domain.user.UserConverter;
 import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
 import fiveguys.Tom.Cafeteria.Server.domain.user.service.UserCommandService;
@@ -20,6 +20,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -28,7 +29,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Controller
 @RequiredArgsConstructor
 public class LoginController {
-    private final KakoLoginService kakoLoginService;
+    private final KakaoLoginService kakaoLoginService;
     private final UserQueryService userQueryService;
     private final UserCommandService userCommandService;
     private final TokenProvider tokenProvider;
@@ -61,7 +62,7 @@ public class LoginController {
         // kakaoLoginService.validate(requestDTO.getIdentityToken());
         // ok -> 유저 정보 가져오기
         KakaoResponseDTO.UserInfoResponseDTO userInfo;
-        userInfo = kakoLoginService.getUserInfo(requestDTO.getAccessToken());
+        userInfo = kakaoLoginService.getUserInfo(requestDTO.getAccessToken());
         // 유저 정보에 DB 조회하고 정보 있으면 응답만, 없으면 저장까지, 추가정보 입력 여부에 따라서 응답 다르게
         String socialId = userInfo.getSocialId();
         User user;
@@ -79,10 +80,11 @@ public class LoginController {
     /*
     테스트용 API
      */
-//    @GetMapping("/oauth2/login/kakao")
-//    public ResponseEntity<String> getAccessToken(@RequestParam(name = "code") String code){
-//        TokenResponse tokenResponse = kakaoLoginService.getAccessTokenByCode(code);
-//        return ResponseEntity.ok("accessToken="+ tokenResponse.getAccessToken() +
-//                "\n\nidToken=" + tokenResponse.getIdToken());
-//    }
+    @GetMapping("/oauth2/login/kakao")
+    @ResponseBody
+    public ResponseEntity<String> getAccessToken(@RequestParam(name = "code") String code){
+        TokenResponse tokenResponse = kakaoLoginService.getAccessTokenByCode(code);
+        return ResponseEntity.ok("accessToken="+ tokenResponse.getAccessToken() +
+                "\n\nidToken=" + tokenResponse.getIdToken());
+    }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/converter/LoginConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/converter/LoginConverter.java
@@ -1,0 +1,14 @@
+package fiveguys.Tom.Cafeteria.Server.auth.converter;
+
+import fiveguys.Tom.Cafeteria.Server.auth.dto.LoginResponseDTO;
+
+public class LoginConverter {
+
+    public static LoginResponseDTO.LoginDTO toLoginDTO(String accessToken, String refreshToken){
+        return LoginResponseDTO.LoginDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/dto/LoginRequestDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/dto/LoginRequestDTO.java
@@ -1,0 +1,16 @@
+package fiveguys.Tom.Cafeteria.Server.auth.dto;
+
+
+import jakarta.validation.Valid;
+import lombok.Getter;
+
+public class LoginRequestDTO {
+
+    @Getter
+    public static class KakaoTokenValidateDTO{
+        private String identityToken;
+        private String accessToken;
+//        @Valid
+//        private AdditionalInfo additionalInfo;
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/dto/LoginResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/dto/LoginResponseDTO.java
@@ -1,0 +1,18 @@
+package fiveguys.Tom.Cafeteria.Server.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class LoginResponseDTO {
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class LoginDTO{
+        private String accessToken;
+        private String refreshToken;
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/JwkResponse.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/JwkResponse.java
@@ -1,0 +1,30 @@
+package fiveguys.Tom.Cafeteria.Server.auth.feignClient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class JwkResponse {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Jwk {
+        private String alg;
+        private String e;
+        private String kid;
+        private String kty;
+        private String n;
+        private String use;
+    }
+    @Getter
+    public static class JwkSet{
+        @JsonProperty("keys")
+        private List<Jwk> jwkList;
+    }
+}
+

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/TokenResponse.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/TokenResponse.java
@@ -1,0 +1,18 @@
+package fiveguys.Tom.Cafeteria.Server.auth.feignClient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+    @JsonProperty("id_token")
+    private String idToken;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("token_type")
+    private String tokenType;
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/config/FeignConfig.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/config/FeignConfig.java
@@ -1,0 +1,17 @@
+package fiveguys.Tom.Cafeteria.Server.auth.feignClient.config;
+
+import feign.codec.Encoder;
+import feign.form.spring.SpringFormEncoder;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.SpringEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class FeignConfig {
+    @Bean
+    public Encoder multipartFormEncoder() {
+        return new SpringFormEncoder(new SpringEncoder(() -> new HttpMessageConverters(new RestTemplate().getMessageConverters())));
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/kakao/KakaoApiClient.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/kakao/KakaoApiClient.java
@@ -1,0 +1,13 @@
+package fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao;
+
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.config.FeignConfig;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao.dto.KakaoResponseDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakao-api-client", url = "https://kapi.kakao.com", configuration = FeignConfig.class)
+public interface KakaoApiClient {
+    @GetMapping(value = "/v1/oidc/userinfo")
+    KakaoResponseDTO.UserInfoResponseDTO getUserInfo(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/kakao/KakaoAuthClient.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/kakao/KakaoAuthClient.java
@@ -1,0 +1,24 @@
+package fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao;
+
+
+import feign.Headers;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.JwkResponse;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.TokenResponse;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.config.FeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "kakao-auth-client", url = "https://kapi.kakao.com", configuration = FeignConfig.class)
+public interface KakaoAuthClient {
+    @Headers("Content-Type: application/x-www-form-urlencoded")
+    @PostMapping("/oauth/token")
+    TokenResponse getAccessToken(@RequestParam(name = "grant_type") String grantType,
+                                 @RequestParam(name = "client_id") String clientId,
+                                 @RequestParam(name = "redirect_uri") String redirectUri,
+                                 @RequestParam(name = "code") String code
+    );
+    @GetMapping("/.well-known/jwks.json")
+    JwkResponse.JwkSet getKeys();
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/kakao/KakaoAuthClient.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/kakao/KakaoAuthClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "kakao-auth-client", url = "https://kapi.kakao.com", configuration = FeignConfig.class)
+@FeignClient(name = "kakao-auth-client", url = "https://kauth.kakao.com", configuration = FeignConfig.class)
 public interface KakaoAuthClient {
     @Headers("Content-Type: application/x-www-form-urlencoded")
     @PostMapping("/oauth/token")

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/kakao/dto/KakaoResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/feignClient/kakao/dto/KakaoResponseDTO.java
@@ -1,0 +1,16 @@
+package fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+public class KakaoResponseDTO {
+    @Getter
+    @ToString
+    public static class UserInfoResponseDTO{
+        @JsonProperty("sub")
+        private String socialId;
+        private String nickname;
+        private String email;
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/JwtToken.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/JwtToken.java
@@ -1,0 +1,15 @@
+package fiveguys.Tom.Cafeteria.Server.auth.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class JwtToken {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtTokenProvider.java
@@ -1,0 +1,45 @@
+package fiveguys.Tom.Cafeteria.Server.auth.jwt.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtTokenProvider implements TokenProvider {
+    @Value("${spring.jwt.secret}")
+    private String secret;
+    private SecretKey secretkey;
+    @PostConstruct
+    public void init() {
+        this.secretkey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+    }
+
+    @Override
+    public boolean verifyToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser()
+                    .verifyWith(secretkey)
+                    .build() // 비밀키를 설정하여 파서를 빌드.
+                    .parseSignedClaims(token);  // 주어진 토큰을 파싱하여 Claims 객체를 얻는다.
+            // 토큰의 만료 시간과 현재 시간비교
+            return claims.getBody()
+                    .getExpiration()
+                    .after(new Date());  // 만료 시간이 현재 시간 이후인지 확인하여 유효성 검사 결과를 반환
+        } catch (Exception e) {
+            log.info("토큰 검증 실패 = {}", token);
+            return false;
+        }
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtUtil.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtUtil.java
@@ -1,0 +1,98 @@
+package fiveguys.Tom.Cafeteria.Server.auth.jwt.service;
+
+
+import fiveguys.Tom.Cafeteria.Server.auth.jwt.JwtToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+/**
+ 토큰의 속성을 정의하고 생성하는 역할
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtUtil {
+    @Value("${spring.jwt.secret}")
+    private String secret;
+    private SecretKey secretkey;
+    @PostConstruct
+    public void init() {
+        this.secretkey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+    }
+
+
+    public JwtToken generateToken(String id) {
+        // refreshToken과 accessToken을 생성한다.
+        String refreshToken = generateRefreshToken(id);
+        String accessToken = generateAccessToken(id);
+        log.info("accessToken = {}", accessToken);
+        return new JwtToken(accessToken, refreshToken);
+    }
+
+    public String generateRefreshToken(String id) {
+        // 토큰의 유효 기간을 밀리초 단위로 설정.
+        long refreshPeriod = 1000L * 60L * 60L * 24L * 14; // 2주
+
+        // 새로운 클레임 객체를 생성하고, 아이디를 셋
+        Claims claims = Jwts.claims()
+                .subject(id)
+                .build();
+        // 현재 시간과 날짜를 가져온다.
+        Date now = new Date();
+
+        return Jwts.builder()
+                // Payload를 구성하는 속성들을 정의한다.
+                .setClaims(claims)
+                // 발행일자를 넣는다.
+                .setIssuedAt(now)
+                // 토큰의 만료일시를 설정한다.
+                .setExpiration(new Date(now.getTime() + refreshPeriod))
+                // 지정된 서명 알고리즘과 비밀 키를 사용하여 토큰을 서명한다.
+                .signWith(secretkey, SignatureAlgorithm.HS256)
+                // JWT의 각 부분을 Base64Url 인코딩하고 이들을 '.'으로 연결하여 최종적인 JWT 문자열을 생성합니다.(URL-safe 문자열로 압축)
+                .compact();
+    }
+
+
+    public String generateAccessToken(String id) {
+
+        long tokenPeriod = 1000L * 60L * 60L; // 60분
+        Claims claims = Jwts.claims()
+                .subject(id)
+                .build();
+
+        Date now = new Date();
+        return
+                Jwts.builder()
+                        // Payload를 구성하는 속성들을 정의한다.
+                        .setClaims(claims)
+                        // 발행일자를 넣는다.
+                        .setIssuedAt(now)
+                        // 토큰의 만료일시를 설정한다.
+                        .setExpiration(new Date(now.getTime() + tokenPeriod))
+                        // 지정된 서명 알고리즘과 비밀 키를 사용하여 토큰을 서명한다.
+                        .signWith(secretkey, SignatureAlgorithm.HS256)
+                        .compact();
+    }
+
+    // 토큰에서 유저 id를추출한다.
+    public String getUserId(String token) {
+        return Jwts.parser()
+                .verifyWith(secretkey)
+                .build() // 비밀키를 설정하여 파서를 빌드.
+                .parseSignedClaims(token)// 주어진 토큰을 파싱하여 Claims 객체를 얻는다.
+                .getPayload()
+                .getSubject();
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/TokenProvider.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/TokenProvider.java
@@ -1,0 +1,5 @@
+package fiveguys.Tom.Cafeteria.Server.auth.jwt.service;
+
+public interface TokenProvider {
+    public boolean verifyToken(String token);
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/service/KakaoLoginService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/service/KakaoLoginService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class KakoLoginService implements LoginService {
+public class KakaoLoginService implements LoginService {
     private final KakaoApiClient kakaoApiClient;
     private final KakaoAuthClient kakaoAuthClient;
 

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/service/KakoLoginService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/service/KakoLoginService.java
@@ -1,0 +1,44 @@
+package fiveguys.Tom.Cafeteria.Server.auth.service;
+
+
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.TokenResponse;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao.KakaoApiClient;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao.KakaoAuthClient;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao.dto.KakaoResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakoLoginService implements LoginService {
+    private final KakaoApiClient kakaoApiClient;
+    private final KakaoAuthClient kakaoAuthClient;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+    @Value("${kakao.admin-key}")
+    private String adminKey;
+
+    public KakaoResponseDTO.UserInfoResponseDTO getUserInfo(String accessToken){
+        String cleanedAccessToken = cleanToken(accessToken);
+        accessToken = "bearer " + cleanedAccessToken;
+        KakaoResponseDTO.UserInfoResponseDTO userInfo = kakaoApiClient.getUserInfo(accessToken);
+        return userInfo;
+    }
+
+    @Override
+    public TokenResponse getAccessTokenByCode(String code) {
+        return kakaoAuthClient.getAccessToken("authorization_code",
+                clientId,
+                redirectUri,
+                code);
+    }
+
+    @Override
+    public void validate(String accessToken) {
+
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/service/LoginService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/service/LoginService.java
@@ -1,0 +1,12 @@
+package fiveguys.Tom.Cafeteria.Server.auth.service;
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.TokenResponse;
+
+public interface LoginService {
+    default String cleanToken(String token){
+        token = token.replaceAll("[\u0000-\u001F\u007F-\u00FF:]", ""); // 헤더에 있으면 안되는 값 대체
+        token = token.trim(); // 앞뒤 공백 제거
+        return token;
+    }
+    public TokenResponse getAccessTokenByCode(String code);
+    public void validate(String accessToken);
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/UserConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/UserConverter.java
@@ -1,0 +1,13 @@
+package fiveguys.Tom.Cafeteria.Server.domain.user;
+
+import fiveguys.Tom.Cafeteria.Server.auth.feignClient.kakao.dto.KakaoResponseDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
+
+public class UserConverter {
+    public static User toUser(KakaoResponseDTO.UserInfoResponseDTO userInfoResponseDTO){
+        return User.builder()
+                .socialId(userInfoResponseDTO.getSocialId())
+                .email(userInfoResponseDTO.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/Role.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/Role.java
@@ -1,0 +1,5 @@
+package fiveguys.Tom.Cafeteria.Server.domain.user.entity;
+
+public enum Role {
+    ADMIN, MEMBER
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/User.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/User.java
@@ -15,10 +15,16 @@ public class User{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String socialId;
+
     @Enumerated(EnumType.STRING)
     private Sex sex;
 
-    private String role;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     private String name;
+
+    private String email;
+
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/repository/UserRepository.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/repository/UserRepository.java
@@ -4,6 +4,10 @@ package fiveguys.Tom.Cafeteria.Server.domain.user.repository;
 import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+import java.util.Optional;
 
+public interface UserRepository extends JpaRepository<User, Long> {
+    public Optional<User> findBySocialId(String socialId);
+
+    public boolean existsBySocialId(String socialId);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserCommandService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserCommandService.java
@@ -1,4 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server.domain.user.service;
 
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
+
 public interface UserCommandService {
+    public User create(User user);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserCommandServiceImpl.java
@@ -1,8 +1,17 @@
 package fiveguys.Tom.Cafeteria.Server.domain.user.service;
 
 
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
+import fiveguys.Tom.Cafeteria.Server.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserCommandServiceImpl implements UserCommandService{
+    private final UserRepository userRepository;
+    @Override
+    public User create(User user) {
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserQueryService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserQueryService.java
@@ -1,4 +1,9 @@
 package fiveguys.Tom.Cafeteria.Server.domain.user.service;
 
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
+
 public interface UserQueryService {
+    public User getUserBySocialId(String socialId);
+
+    boolean isExistBySocialId(String socialId);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserQueryServiceImpl.java
@@ -1,7 +1,26 @@
 package fiveguys.Tom.Cafeteria.Server.domain.user.service;
 
+import fiveguys.Tom.Cafeteria.Server.apiPayload.code.status.ErrorStatus;
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
+import fiveguys.Tom.Cafeteria.Server.domain.user.repository.UserRepository;
+import fiveguys.Tom.Cafeteria.Server.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserQueryServiceImpl implements UserQueryService{
+    private final UserRepository userRepository;
+
+    @Override
+    public User getUserBySocialId(String socialId) {
+        return userRepository.findBySocialId(socialId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND)
+        );
+    }
+
+    @Override
+    public boolean isExistBySocialId(String socialId) {
+        return userRepository.existsBySocialId(socialId);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     secret: ${JWT_SECRET}
 logging:
   level:
-    com.onnoff.onnoff.auth.feignClient: DEBUG
+    fiveguys.Tom.Cafeteria.Server.auth.feignClient : DEBUG
 apple:
   redirect-uri: ${APPLE_REDIRECT_URI}
   iss: https://appleid.apple.com


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19 

## 📝작업 내용

> 
1. 카카오 소셜 로그인 창 이동 API 구현
2. 카카오 인가코드 받아 액세스 토큰 받는 로직 구현 
3. 카카오 액세스 토큰으로 기본 정보 받아와 DB에 저장, 만약 이미 저장되어있다면 토큰만 반환
실제로는 앱 환경에서 1,2번은 사용하지 않음, 그냥 테스트용. ID 토큰 받아서 검증하는 로직은 아직 미구현

