### PR TITLE
[feat]: 휴무일 체크 API 수정

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/entity/Cafeteria.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/entity/Cafeteria.java
@@ -1,6 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity;
 
 
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -12,7 +13,7 @@ import java.time.LocalTime;
 @AllArgsConstructor
 @ToString
 @Entity
-public class Cafeteria {
+public class Cafeteria extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/common/BaseEntity.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package fiveguys.Tom.Cafeteria.Server.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    protected LocalDateTime createdAt; // 생성 시간
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt; // 수정 시간
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
@@ -5,6 +5,7 @@ import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.service.CafeteriaQueryService;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietRequestDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.MenuDiet;
@@ -82,11 +83,10 @@ public class AdminDietController {
         dietCommandService.switchSoldOut(diet);
         return ApiResponse.onSuccess(DietConverter.toSwitchSoldOutResponseDTO(diet.isSoldOut()));
     }
-    @Operation(summary = "해당 식단 날짜의 휴무를 체크하는 API", description = "토글 형식으로 휴무를 표시한다 응답으로 dayOff가 true이면 휴무")
-    @PatchMapping("/{dietId}/dayOff")
-    public ApiResponse<DietResponseDTO.SwitchDayOffResponseDTO> checkDayOff(@PathVariable(name = "dietId") Long dietId){
-        Diet diet = dietQueryService.getDiet(dietId);
-        dietCommandService.switchDayOff(diet);
-        return ApiResponse.onSuccess(DietConverter.toSwitchDayOffResponseDTO(diet.isDayOff()));
+    @Operation(summary = "해당 식단 날짜의 휴무를 체크하는 API", description = "식당 ID와 날짜를 받아서 토글 형식으로 휴무를 표시한다 응답으로 dayOff가 true이면 휴무")
+    @PatchMapping("/dayOff")
+    public ApiResponse<DietResponseDTO.SwitchDayOffResponseDTO> checkDayOff(@RequestBody DietRequestDTO.CheckDayOffDTO requestDTO){
+        Diet switchedDiet = dietCommandService.switchDayOff(requestDTO);
+        return ApiResponse.onSuccess(DietConverter.toSwitchDayOffResponseDTO(switchedDiet.isDayOff()));
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
@@ -83,7 +83,8 @@ public class AdminDietController {
         dietCommandService.switchSoldOut(diet);
         return ApiResponse.onSuccess(DietConverter.toSwitchSoldOutResponseDTO(diet.isSoldOut()));
     }
-    @Operation(summary = "해당 식단 날짜의 휴무를 체크하는 API", description = "식당 ID와 날짜를 받아서 토글 형식으로 휴무를 표시한다 응답으로 dayOff가 true이면 휴무")
+    @Operation(summary = "해당 식단 날짜의 휴무를 체크하는 API", description = "식당 ID와 날짜를 받아서 토글 형식으로 휴무를 표시한다. 응답으로 dayOff가 true이면 휴무" +
+            "만약 해당 날짜에 식단이 없다면 아침 식단을 만들고 휴무로 등록")
     @PatchMapping("/dayOff")
     public ApiResponse<DietResponseDTO.SwitchDayOffResponseDTO> checkDayOff(@RequestBody DietRequestDTO.CheckDayOffDTO requestDTO){
         Diet switchedDiet = dietCommandService.switchDayOff(requestDTO);

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
@@ -4,7 +4,6 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.converter;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseDTO;
-import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
@@ -25,6 +24,7 @@ public class DietConverter {
 
     public static DietResponseDTO.DietQueryDTO toDietResponseDTO(Diet diet, MenuResponseDTO.MenuResponseListDTO menuResponseListDTO){
         return DietResponseDTO.DietQueryDTO.builder()
+                .dietId(diet.getId())
                 .menuResponseListDTO(menuResponseListDTO)
                 .photoURI(diet.getDietPhoto() != null ? dietPhotoURI + diet.getDietPhoto().getImageKey() : "사진이 등록되어있지 않습니다.")
                 .dayOff(diet.isDayOff())

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietRequestDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietRequestDTO.java
@@ -4,6 +4,7 @@ import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDate;
 
@@ -27,5 +28,12 @@ public class DietRequestDTO {
         private int month;
         private int weekNum;
         private Meals meals;
+    }
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CheckDayOffDTO{
+       private Long cafeteriaId;
+       private LocalDate localDate;
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietResponseDTO.java
@@ -28,7 +28,7 @@ public class DietResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DietQueryDTO {
-        private Long id;
+        private Long dietId;
         private LocalDate date;
         private String photoURI;
         private MenuResponseDTO.MenuResponseListDTO menuResponseListDTO;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/Diet.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/Diet.java
@@ -1,6 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.entity;
 
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.DietPhoto;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 import jakarta.persistence.*;
@@ -21,7 +22,7 @@ import java.util.Locale;
 @AllArgsConstructor
 @ToString
 @Entity
-public class Diet {
+public class Diet extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/MenuDiet.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/MenuDiet.java
@@ -1,6 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.entity;
 
 
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,7 +12,7 @@ import lombok.*;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class MenuDiet {
+public class MenuDiet extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepository.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DietRepository extends JpaRepository<Diet, Long> {
+    List<Diet> findByCafeteriaAndLocalDate(Cafeteria cafeteria, LocalDate localDate);
     Optional<Diet> findByCafeteriaAndLocalDateAndMeals(Cafeteria cafeteria, LocalDate date, Meals meals);
     List<Diet> findAllByCafeteriaAndYearAndMonthAndWeekAndMeals(Cafeteria cafeteria, int year, int month, int week, Meals meals);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietCommandService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietCommandService.java
@@ -1,6 +1,8 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.service;
 
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietRequestDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 
@@ -15,6 +17,6 @@ public interface DietCommandService {
 
     public Diet switchSoldOut(Diet diet);
 
-    public Diet switchDayOff(Diet diet);
+    public Diet switchDayOff(DietRequestDTO.CheckDayOffDTO checkDayOffDTO);
 
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryService.java
@@ -12,6 +12,7 @@ public interface DietQueryService {
 
     public Diet getDiet(Long dietId);
     public Diet getDiet(Cafeteria cafeteria, LocalDate localDate, Meals meals);
+    public List<Diet> getDietsOfDay(Cafeteria cafeteria, LocalDate localDate);
     public List<Diet> getDietListOfWeek(Cafeteria cafeteria, int year, int month, int weekNum, Meals meals);
 
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryServiceImpl.java
@@ -34,6 +34,11 @@ public class DietQueryServiceImpl implements DietQueryService{
     }
 
     @Override
+    public List<Diet> getDietsOfDay(Cafeteria cafeteria, LocalDate localDate) {
+        return dietRepository.findByCafeteriaAndLocalDate(cafeteria, localDate);
+    }
+
+    @Override
     public List<Diet> getDietListOfWeek(Cafeteria cafeteria, int year, int month, int weekNum, Meals meals) {
         List<Diet> dietList = dietRepository
                 .findAllByCafeteriaAndYearAndMonthAndWeekAndMeals(cafeteria, year, month, weekNum, meals);

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/Menu.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/Menu.java
@@ -1,6 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server.domain.menu.entity;
 
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import lombok.*;
 @AllArgsConstructor
 @ToString
 @Entity
-public class Menu {
+public class Menu extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/MenuCategory.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/MenuCategory.java
@@ -1,5 +1,6 @@
 package fiveguys.Tom.Cafeteria.Server.domain.menu.entity;
 
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,7 +13,7 @@ import lombok.*;
 @AllArgsConstructor
 @ToString
 @Entity
-public class MenuCategory {
+public class MenuCategory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/User.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server.domain.user.entity;
 
 
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import lombok.*;
 @AllArgsConstructor
 @ToString
 @Entity
-public class User{
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #21 

## 📝작업 내용

> 
1. 휴무일 체크 API 날짜 기준으로 변경
2. 모든 엔티티에 생성/수정 날짜 추가 (BaseEntity 상속)