### PR TITLE
[fix]: 푸시 알림 작업 중 깃이 꼬여서 브랜치 다시 파서 머지

### DIFF
--- a/.ebextensions_dev/00-makeFiles.config
+++ b/.ebextensions_dev/00-makeFiles.config
@@ -6,6 +6,11 @@ files:
         content: |
             #!/usr/bin/env bash
             JAR_PATH=/var/app/current/application.jar
+
+            # Copy keyfile from S3
+            aws s3 cp s3://tam-cafeteria-dev/keys/AuthKey_G7T8QJF8A7.p8 /var/app/current/src/main/resources/AuthKey_G7T8QJF8A7.p8
+            aws s3 cp s3://tam-cafeteria-dev/keys/tam-fcm-firebase-adminsdk-ch4qp-ba35284c07.json /var/app/current/src/main/resources/tam-fcm-firebase-adminsdk-ch4qp-ba35284c07.json
+
             # run app
             killall java
             java -Dfile.encoding=UTF-8 -jar $JAR_PATH

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
@@ -30,6 +30,7 @@ public class DietConverter {
                 .photoURI(diet.getDietPhoto() != null ? dietPhotoURI + diet.getDietPhoto().getImageKey() : "사진이 등록되어있지 않습니다.")
                 .dayOff(diet.isDayOff())
                 .soldOut(diet.isSoldOut())
+                .date(diet.getLocalDate())
                 .build();
     }
     public static DietResponseDTO.DietCreateDTO toDietCreateResponseDTO(Diet diet){

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/controller/FCMAdminController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/controller/FCMAdminController.java
@@ -1,0 +1,41 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.controller;
+
+import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
+import fiveguys.Tom.Cafeteria.Server.domain.notification.dto.NotificationRequestDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/notifications")
+public class FCMAdminController {
+    private final NotificationService notificationService;
+
+    @Operation(summary = "특정 사용자에게 알림을 보내는 API", description = "식당id, 내용, 받는 유저 id를")
+    @PostMapping("/general/user")
+    public ApiResponse<String> sendOne(@RequestBody NotificationRequestDTO.SendOneDTO dto){
+        notificationService.sendOne(dto.getCafeteriaId(), dto.getContent(), dto.getReceiverId());
+        return ApiResponse.onSuccess("알림을 성공적으로 보냈습니다.");
+    }
+
+    @Operation(summary = "알림을 허용한 모두에게 공지를 보내는 API", description = "식당 관리자 -> 이용자가 아닌 앱 관리자 -> 이용자 용도의 공지 API")
+    @PostMapping("/general/users")
+    public ApiResponse<String> sendAll(@RequestBody NotificationRequestDTO.SendAllDTO dto){
+        notificationService.sendAll(dto);
+        return ApiResponse.onSuccess("알림을 성공적으로 보냈습니다.");
+    }
+
+    @Operation(summary = "식당을 구독한 이용자에게 공지를 보내는 API", description = "식당명과 알림 타입을 받아서 구독을 특정하여 메시지를 전달한다.")
+    @PostMapping("/topic/subscriber")
+    public ApiResponse<String> sendSubscriber(@RequestBody NotificationRequestDTO.SendSubscriberDTO dto){
+        notificationService.sendSubScriber(dto);
+        return ApiResponse.onSuccess("알림을 성공적으로 보냈습니다.");
+    }
+
+}
+

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/dto/NotificationRequestDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/dto/NotificationRequestDTO.java
@@ -1,0 +1,26 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.dto;
+
+import fiveguys.Tom.Cafeteria.Server.domain.notification.entity.AppNotificationType;
+import lombok.Getter;
+
+public class NotificationRequestDTO {
+    @Getter
+    public static class SendOneDTO{
+        private Long cafeteriaId;
+        private String content;
+        private Long receiverId;
+    }
+
+    @Getter
+    public static class SendAllDTO{
+        private String title;
+        private String content;
+    }
+    @Getter
+    public static class SendSubscriberDTO{
+        private String title;
+        private String content;
+        private String cafeteriaName;
+        private AppNotificationType notificationType;
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/entity/AppNotification.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/entity/AppNotification.java
@@ -1,0 +1,27 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.entity;
+
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppNotification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/entity/AppNotificationType.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/entity/AppNotificationType.java
@@ -1,0 +1,5 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.entity;
+
+public enum AppNotificationType {
+    today_diet, week_diet_enroll, diet_photo_enroll, diet_sold_out, diet_change
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/entity/UserAppNotification.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/entity/UserAppNotification.java
@@ -1,0 +1,32 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.entity;
+
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.NotificationSet;
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserAppNotification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch= FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch= FetchType.LAZY)
+    private AppNotification appNotification;
+
+    @Column(columnDefinition = "boolean DEFAULT false", name = "is_read") //mysql 예약어 피하기
+    private boolean read;
+
+}
+

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/repository/AppNotificationRepository.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/repository/AppNotificationRepository.java
@@ -1,0 +1,8 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.repository;
+
+import fiveguys.Tom.Cafeteria.Server.domain.notification.entity.AppNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppNotificationRepository extends JpaRepository<AppNotification, Long> {
+}
+

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMService.java
@@ -1,0 +1,14 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.service;
+
+import com.google.firebase.messaging.Message;
+import org.springframework.scheduling.annotation.Async;
+
+public interface FCMService {
+    public void sendMessageByTopic(Message message);
+    public Message createMessage(String title, String content, String cafeteriaName, String type, Long notificationId);
+    public Message createGeneralMessage(String title, String content, Long notificationId);
+
+    public Message createPMessage(String title, String content, String token);
+
+    public Long storeNotification(String title, String content);
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMServiceImpl.java
@@ -1,0 +1,75 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.service;
+
+import com.google.firebase.messaging.*;
+import fiveguys.Tom.Cafeteria.Server.domain.notification.entity.AppNotification;
+import fiveguys.Tom.Cafeteria.Server.domain.notification.repository.AppNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FCMServiceImpl implements FCMService{
+    private final AppNotificationRepository notificationRepository;
+
+    @Override
+    public void sendMessageByTopic(Message message) {
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("response = {}", response);
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Message createMessage(String title, String content, String cafeteriaName, String type, Long notificationId) {
+        String condition = "'" + cafeteriaName + "' in topics && '" + type + "' in topics";
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(content)
+                .build();
+        return Message.builder()
+                .putData("id", String.valueOf(notificationId))
+                .setCondition(condition)
+                .setNotification(notification)
+                .build();
+    }
+
+    @Override
+    public Message createGeneralMessage(String title, String content, Long notificationId) {
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(content)
+                .build();
+
+        return Message.builder()
+                .putData("id", String.valueOf(notificationId))
+                .setTopic("general")
+                .setNotification(notification)
+                .build();
+    }
+
+    @Override
+    public Message createPMessage(String title, String content, String token) {
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(content)
+                .build();
+
+        return Message.builder()
+                .setToken(token)
+                .setNotification(notification)
+                .build();
+    }
+    @Override
+    public Long storeNotification(String title, String content){
+        AppNotification notification = AppNotification.builder()
+                .title(title)
+                .content(content)
+                .build();
+        return notificationRepository.save(notification).getId();
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/NotificationService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/NotificationService.java
@@ -1,0 +1,11 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.service;
+
+import fiveguys.Tom.Cafeteria.Server.domain.notification.dto.NotificationRequestDTO;
+
+public interface NotificationService {
+    public void sendAll(NotificationRequestDTO.SendAllDTO dto);
+
+    public void sendSubScriber(NotificationRequestDTO.SendSubscriberDTO dto);
+
+    public void sendOne(Long cafeteriaId, String content, Long receiverId);
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,69 @@
+package fiveguys.Tom.Cafeteria.Server.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Notification;
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.service.CafeteriaQueryService;
+import fiveguys.Tom.Cafeteria.Server.domain.notification.dto.NotificationRequestDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
+import fiveguys.Tom.Cafeteria.Server.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.google.firebase.messaging.Message;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService{
+    private final FCMService fcmService;
+    private final UserQueryService userQueryService;
+    private final CafeteriaQueryService cafeteriaQueryService;
+
+    @Override
+    public void sendAll(NotificationRequestDTO.SendAllDTO dto) {
+        Long storedNotificationId = fcmService.storeNotification(dto.getTitle(), dto.getContent());
+        Message message = fcmService.createGeneralMessage(dto.getTitle(), dto.getContent(), storedNotificationId);
+        fcmService.sendMessageByTopic(message);
+    }
+
+    @Override
+    public void sendSubScriber(NotificationRequestDTO.SendSubscriberDTO dto) {
+        Long storedNotificationId = fcmService.storeNotification(dto.getTitle(), dto.getContent());
+        Message message = fcmService.createMessage(dto.getTitle(), dto.getContent(), dto.getCafeteriaName(), dto.getNotificationType().name(), storedNotificationId);
+        fcmService.sendMessageByTopic(message);
+    }
+
+    @Override
+    public void sendOne(Long cafeteriaId, String content, Long receiverId) {
+        User receiver = userQueryService.getUserById(receiverId);
+        Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
+        String registrationToken = "fgdaEkcYQPepOZCKU9klN_:APA91bEAcajJGUyQeaXC7YVe2Z5OhNn7L96ncHDtllH4vcyczAWUN5m3riHLjYR_BkIThikIclXywlu9pizq3g2j7IvYv16ZEGWo4T4ROVTi5besccZLmn9o96m3-QIgsuuDMaK20FpS";
+
+        // See documentation on defining a message payload.
+        Notification notification = Notification.builder()
+                .setTitle("하이")
+                .setBody(content)
+                .build();
+
+        Message message = Message.builder()
+                .putData("식당", cafeteria.getName())
+                .putData("내용", content)
+                .setToken(registrationToken)
+                .setNotification(notification)
+                .build();
+
+
+
+        // Send a message to the device corresponding to the provided
+        // registration token.
+        String response = null;
+        try {
+            response = FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException(e);
+        }
+        // Response is a message ID string.
+        System.out.println("Successfully sent message: " + response);
+    }
+
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/controller/UserController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/controller/UserController.java
@@ -1,9 +1,27 @@
 package fiveguys.Tom.Cafeteria.Server.domain.user.controller;
 
 
+import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
+import fiveguys.Tom.Cafeteria.Server.domain.user.service.UserCommandService;
+import fiveguys.Tom.Cafeteria.Server.domain.user.service.UserQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
 public class UserController {
-
+    private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+    @PostMapping("/notificationSet")
+    @Operation(summary = "알림을 허용시 호출하는 API", description = "기기토큰을 저장시키고" +
+            " general 토픽에 대해서 구독을 실시한다, 모든 알림 타입에 대해서도 on 상태")
+    public ApiResponse<String> allowNotification(@RequestParam(name = "registrationToken") String token){
+        userCommandService.initNotificationSet(token);
+        return ApiResponse.onSuccess("알림이 활성화 되었습니다.");
+    }
 
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/NotificationSet.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/NotificationSet.java
@@ -1,0 +1,30 @@
+package fiveguys.Tom.Cafeteria.Server.domain.user.entity;
+
+import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationSet extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String registrationToken;
+
+    @Column(columnDefinition = "boolean default true")
+    private boolean todayDiet;
+    @Column(columnDefinition = "boolean default true")
+    private boolean weekDiet;
+    @Column(columnDefinition = "boolean default true")
+    private boolean soldOut;
+    @Column(columnDefinition = "boolean default true")
+    private boolean dietModification;
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/User.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/entity/User.java
@@ -34,7 +34,10 @@ public class User extends BaseEntity {
     private String email;
     private String password;
     private String appleRefreshToken;
+    private String registrationToken;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private NotificationSet notificationSet;
     public static void setRoleAdmin(User user) {
         user.role = Role.ADMIN;
     }
@@ -44,6 +47,14 @@ public class User extends BaseEntity {
 
     public static void setAppleRefreshToken(User user, String appleRefreshToken){
         user.setAppleRefreshToken(appleRefreshToken);
+    }
+
+    public void setNotificationSet(NotificationSet notificationSet) {
+        this.notificationSet = notificationSet;
+    }
+
+    public void setRegistrationToken(String registrationToken) {
+        this.registrationToken = registrationToken;
     }
 
     private void setAppleRefreshToken(String appleRefreshToken) {

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserCommandService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserCommandService.java
@@ -8,4 +8,6 @@ public interface UserCommandService {
     public void grantAdmin(Long userId);
 
     public void depriveAdmin(Long userId);
+
+    public void initNotificationSet(String token);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/user/service/UserCommandServiceImpl.java
@@ -1,16 +1,28 @@
 package fiveguys.Tom.Cafeteria.Server.domain.user.service;
 
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.TopicManagementResponse;
+import fiveguys.Tom.Cafeteria.Server.auth.UserContext;
+import fiveguys.Tom.Cafeteria.Server.domain.user.entity.NotificationSet;
 import fiveguys.Tom.Cafeteria.Server.domain.user.entity.User;
 import fiveguys.Tom.Cafeteria.Server.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserCommandServiceImpl implements UserCommandService{
     private final UserQueryService userQueryService;
     private final UserRepository userRepository;
+
+
     @Override
     public User create(User user) {
         return userRepository.save(user);
@@ -26,5 +38,32 @@ public class UserCommandServiceImpl implements UserCommandService{
     public void depriveAdmin(Long userId) {
         User user = userQueryService.getUserById(userId);
         User.setRoleMember(user);
+    }
+
+    @Transactional
+    @Override
+    public void initNotificationSet(String token) {
+        // 알림 정보 생성 및 저장
+        Long id = UserContext.getUserId();
+        User user = userQueryService.getUserById(id);
+        NotificationSet newNotificationSet = NotificationSet.builder()
+                .todayDiet(true)
+                .weekDiet(true)
+                .dietModification(true)
+                .soldOut(true)
+                .registrationToken(token)
+                .build();
+        user.setNotificationSet(newNotificationSet);
+        // general topic 구독
+        ArrayList<String> tokenList = new ArrayList<>();
+        tokenList.add(token);
+        TopicManagementResponse response = null;
+
+        try {
+            response = FirebaseMessaging.getInstance().subscribeToTopic(tokenList, "general");
+            log.info("tokens were subscribed successfully");
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #33 

## 📝작업 내용

> 
1. 유저 알림 초기화 API 구현
2. 관리자 푸시알림 전송 및 저장 API 구현(모두에게 일괄적으로 보내는 API, 식당/타입에 따라 보내는 API)
3. 빈스톡 배포 시 리눅스 설정 파일에 s3에 있는 키파일 복사하는 로직 추가
+ 금주 식단표 응답 date잘 전달하도록 수정
