### PR TITLE
[refactor]: board -> post 이름 변경, 게시물 리스트 조회 메서드 분리

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/controller/PostController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/controller/PostController.java
@@ -3,6 +3,7 @@ package fiveguys.Tom.Cafeteria.Server.domain.board.controller;
 import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
 import fiveguys.Tom.Cafeteria.Server.domain.board.dto.*;
 import fiveguys.Tom.Cafeteria.Server.domain.board.entity.BoardType;
+import fiveguys.Tom.Cafeteria.Server.domain.board.entity.OrderType;
 import fiveguys.Tom.Cafeteria.Server.domain.board.entity.Post;
 import fiveguys.Tom.Cafeteria.Server.domain.board.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,9 +14,9 @@ import java.util.List;
 
 
 @RestController
-@RequestMapping("/boards")
+@RequestMapping("/posts")
 @RequiredArgsConstructor
-public class BoardController {
+public class PostController {
 
     private final PostService postService;
 
@@ -28,14 +29,30 @@ public class BoardController {
     }
 
     // 특정 게시판의 전체 게시글 조회
-    @Operation(summary = "게시글 리스트 최신순 조회 API", description = "최신 순으로 정렬하여 받을 페이지를 인자로 받아 응답한다")
-    @GetMapping("/{boardType}/boards")
-    public ApiResponse<List<PostPreviewDTO>> getAllBoardsByType(@PathVariable("boardType") BoardType boardType,
-                                                                @RequestParam(name = "cafeteriaId") Long cafeteriaId,
-                                                                @RequestParam(name = "page") int page ) {
-        List<PostPreviewDTO> postList = postService.getPostPageOrderedByTime(boardType, cafeteriaId, page);
+    @Operation(summary = "메뉴 건의 게시글 리스트 조회 API", description = "메뉴건의 요청 게시글 리스트를 조회한다. orderType을 통해 정렬할 기준을 page를 통해 받을 페이지를 받아 응답한다")
+    @GetMapping("/menu-request")
+    public ApiResponse<List<PostPreviewDTO>> getAllMenuRequestPosts(@RequestParam(name = "cafeteriaId") Long cafeteriaId,
+                                                                @RequestParam(name = "page") int page,
+                                                                @RequestParam(name = "orderType") OrderType orderType) {
+        List<PostPreviewDTO> postList;
+        if(orderType.equals(OrderType.TIME)) {
+            postList = postService.getPostPageOrderedByTime(BoardType.MENU_REQUEST, cafeteriaId, page);
+        }
+        else{
+            postList = postService.getPostPageOrderedByLike(BoardType.MENU_REQUEST, cafeteriaId, page);
+        }
         return ApiResponse.onSuccess(postList);
     }
+
+    @Operation(summary = "메뉴 건의 게시글 리스트 조회 API", description = "공지사항 게시글 리스트를 조회한다. page를 통해 최신순으로 정렬된 페이지 목록을 응답한다")
+    @GetMapping("/notice")
+    public ApiResponse<List<PostPreviewDTO>> getAllNoticePosts(@RequestParam(name = "cafeteriaId") Long cafeteriaId,
+                                                                @RequestParam(name = "page") int page) {
+        List<PostPreviewDTO> postList;
+        postList = postService.getPostPageOrderedByTime(BoardType.NOTICE, cafeteriaId, page);
+        return ApiResponse.onSuccess(postList);
+    }
+
 
 
     //특정 게시글 조회

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/dto/PostPreviewDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/dto/PostPreviewDTO.java
@@ -15,6 +15,7 @@ public class PostPreviewDTO {
     private String title;
     private String content;
     private String publisherName;
+    private int likeCount;
     private LocalDateTime uploadTime;
     //DTO 수정하고 Controller, Service 수정해야함
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/entity/OrderType.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/entity/OrderType.java
@@ -1,0 +1,5 @@
+package fiveguys.Tom.Cafeteria.Server.domain.board.entity;
+
+public enum OrderType {
+    TIME, LIKE
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/service/PostService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/service/PostService.java
@@ -60,7 +60,7 @@ public class PostService {
     public List<PostPreviewDTO> getPostPageOrderedByTime(BoardType boardType, Long cafeteriaId, int page) {
         Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
         Page<Post> userPage = postRepository.findAllByCafeteriaAndBoardType(
-                PageRequest.of(page - 1, postPageSize, Sort.by(Sort.Order.desc("createdAt") ) ),
+                PageRequest.of(page - 1, postPageSize, Sort.by(Sort.Order.asc("createdAt") ) ),
                 cafeteria, boardType);
         List<PostPreviewDTO> postPreviewDTOList = userPage.stream()
                 .map(post -> PostPreviewDTO.builder()
@@ -68,6 +68,7 @@ public class PostService {
                         .title(post.getTitle())
                         .content(post.getContent())
                         .publisherName(post.getUser().getName())
+                        .likeCount(post.getLikeCount())
                         .uploadTime(post.getCreatedAt())
                         .build()
                 )
@@ -76,23 +77,27 @@ public class PostService {
         return postPreviewDTOList;
     }
 
-//    public List<PostPreviewDTO> getPostPageOrderedByLike(BoardType boardType, Long cafeteriaId, int page) {
-//        Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
-//        Page<Post> userPage = postRepository.findAllByCafeteriaAndBoardType(
-//                PageRequest.of(page - 1, postPageSize, Sort.by(Sort.Order.desc("createdAt") ) ),
-//                cafeteria, boardType);
-//        List<PostPreviewDTO> postPreviewDTOList = userPage.stream()
-//                .map(post -> PostPreviewDTO.builder()
-//                        .id(post.getId())
-//                        .title(post.getTitle())
-//                        .publisherName(post.getUser().getName())
-//                        .uploadTime(post.getCreatedAt())
-//                        .build()
-//                )
-//                .collect(Collectors.toList());
-//
-//        return postPreviewDTOList;
-//    }
+    public List<PostPreviewDTO> getPostPageOrderedByLike(BoardType boardType, Long cafeteriaId, int page) {
+        Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
+        Page<Post> userPage = postRepository.findAllByCafeteriaAndBoardType(
+                PageRequest.of(page - 1, postPageSize, Sort.by(
+                        Sort.Order.desc("likeCount"),
+                        Sort.Order.asc("createdAt") ) ),
+                cafeteria, boardType);
+        List<PostPreviewDTO> postPreviewDTOList = userPage.stream()
+                .map(post -> PostPreviewDTO.builder()
+                        .id(post.getId())
+                        .title(post.getTitle())
+                        .content(post.getContent())
+                        .publisherName(post.getUser().getName())
+                        .likeCount(post.getLikeCount())
+                        .uploadTime(post.getCreatedAt())
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        return postPreviewDTOList;
+    }
 
 
     //특정 게시물 조회
@@ -112,23 +117,6 @@ public class PostService {
         // 기타 필요한 속성 설정
         return responseDTO;
     }
-
-//    public BoardResponseDTO updateBoard(Long id, BoardUpdateDTO boardDetails) {
-//
-//        Post post = postRepository.findById(id).orElseThrow(
-//                () -> new IllegalArgumentException("Invalid board Id:" + id));
-//
-//        post.setTitle(boardDetails.getTitle());
-//        post.setContent(boardDetails.getContent());
-//        post.setBoardType(boardDetails.getBoardType());
-//        // board.setLikeCount(boardDetails.getLikeCount()); // 직접 수정 불가 필드 제외
-//        post.setAdminPick(boardDetails.isAdminPick());
-//
-//        post = postRepository.save(post);
-//
-//        // Board 엔티티를 BoardResponseDTO로 변환
-//        return convertToBoardResponseDTO(post);
-//    }
 
 //    public void deleteBoard(Long id) {
 //        Post post = postRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid board Id:" + id));
@@ -166,20 +154,5 @@ public class PostService {
 
         postRepository.delete(post);
     }
-
-
-//    // Board 엔티티를 BoardResponseDTO로 변환하는 메소드
-//    private BoardResponseDTO convertToBoardResponseDTO(Post post) {
-//        BoardResponseDTO dto = new BoardResponseDTO();
-//        dto.setId(post.getId());
-//        dto.setTitle(post.getTitle());
-//        dto.setContent(post.getContent());
-//        dto.setBoardType(post.getBoardType());
-//        dto.setLikeCount(post.getLikeCount());
-//        dto.setAdminPick(post.isAdminPick());
-//        // 필요한 다른 필드들도 여기에 추가
-//        return dto;
-//    }
-
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5 

## 📝작업 내용

> 
1. 컨트롤러 파일명, 메서드명, API Path board -> post로 이름 변경
2. 게시물 리스트 조회 메서드 postType 별로 분리
3. 게시물 리스트 조회 응답에 좋아요 수 추가
