### PR TITLE
[fix]: 게시글 삭제 시 신고 테이블에서도 삭제하도록 수정

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/service/PostService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/service/PostService.java
@@ -191,6 +191,7 @@ public class PostService {
         if( !user.equals(post.getUser()) && user.getRole().equals(Role.MEMBER)){ // 본인이 아니거나 관리자가 아니면 예외
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
+        reportRepository.deleteAllByPost(post);
         postLikeRepository.deleteAllByPost(post);
         postRepository.delete(post);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5 

외래키 조건에 걸려 post 삭제가 되지 않던 이슈

## 📝작업 내용

> 
1. 게시글 신고 로직에 post와 연관된 Report 테이블 삭제 추가