### PR TITLE
[feat]: 게시물 페이징 응답에 현재 페이지와 전체 페이지 응답 추가

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/controller/PostController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/controller/PostController.java
@@ -31,10 +31,10 @@ public class PostController {
     // 특정 게시판의 전체 게시글 조회
     @Operation(summary = "메뉴 건의 게시글 리스트 조회 API", description = "메뉴건의 요청 게시글 리스트를 조회한다. orderType을 통해 정렬할 기준을 page를 통해 받을 페이지를 받아 응답한다")
     @GetMapping("/menu-request")
-    public ApiResponse<List<PostPreviewDTO>> getAllMenuRequestPosts(@RequestParam(name = "cafeteriaId") Long cafeteriaId,
+    public ApiResponse<PostPreviewListDTO> getAllMenuRequestPosts(@RequestParam(name = "cafeteriaId") Long cafeteriaId,
                                                                 @RequestParam(name = "page") int page,
                                                                 @RequestParam(name = "orderType") OrderType orderType) {
-        List<PostPreviewDTO> postList;
+        PostPreviewListDTO postList;
         if(orderType.equals(OrderType.TIME)) {
             postList = postService.getPostPageOrderedByTime(BoardType.MENU_REQUEST, cafeteriaId, page);
         }
@@ -46,9 +46,9 @@ public class PostController {
 
     @Operation(summary = "공지 게시글 리스트 조회 API", description = "공지사항 게시글 리스트를 조회한다. page를 통해 최신순으로 정렬된 페이지 목록을 응답한다")
     @GetMapping("/notice")
-    public ApiResponse<List<PostPreviewDTO>> getAllNoticePosts(@RequestParam(name = "cafeteriaId") Long cafeteriaId,
+    public ApiResponse<PostPreviewListDTO> getAllNoticePosts(@RequestParam(name = "cafeteriaId") Long cafeteriaId,
                                                                 @RequestParam(name = "page") int page) {
-        List<PostPreviewDTO> postList;
+        PostPreviewListDTO postList;
         postList = postService.getPostPageOrderedByTime(BoardType.NOTICE, cafeteriaId, page);
         return ApiResponse.onSuccess(postList);
     }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/dto/PostPreviewListDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/dto/PostPreviewListDTO.java
@@ -1,0 +1,16 @@
+package fiveguys.Tom.Cafeteria.Server.domain.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PostPreviewListDTO {
+    private List<PostPreviewDTO> postPreviewDTOList;
+    private int currentPage;
+    private int totalPages;
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/service/PostService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/board/service/PostService.java
@@ -57,13 +57,15 @@ public class PostService {
     }
 
     //boardType에 따라 특정 게시판의 전체 게시물 조회
-    public List<PostPreviewDTO> getPostPageOrderedByTime(BoardType boardType, Long cafeteriaId, int page) {
+    public PostPreviewListDTO getPostPageOrderedByTime(BoardType boardType, Long cafeteriaId, int page) {
         Long userId = UserContext.getUserId();
         User user = userQueryService.getUserById(userId);
         Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
         Page<Post> userPage = postRepository.findAllByCafeteriaAndBoardType(
                 PageRequest.of(page - 1, postPageSize, Sort.by(Sort.Order.desc("createdAt") ) ),
                 cafeteria, boardType);
+        int totalPages = userPage.getTotalPages() + 1;
+        int currentPage = userPage.getNumber() + 1;
         List<PostPreviewDTO> postPreviewDTOList = userPage.stream()
                 .map(post -> PostPreviewDTO.builder()
                         .id(post.getId())
@@ -76,17 +78,24 @@ public class PostService {
                         .build()
                 )
                 .collect(Collectors.toList());
+        PostPreviewListDTO postPreviewListDTO = PostPreviewListDTO.builder()
+                .currentPage(currentPage)
+                .totalPages(totalPages)
+                .postPreviewDTOList(postPreviewDTOList)
+                .build();
 
-        return postPreviewDTOList;
+        return postPreviewListDTO;
     }
 
-    public List<PostPreviewDTO> getPostPageOrderedByLike(BoardType boardType, Long cafeteriaId, int page) {
+    public PostPreviewListDTO getPostPageOrderedByLike(BoardType boardType, Long cafeteriaId, int page) {
         Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
         Page<Post> userPage = postRepository.findAllByCafeteriaAndBoardType(
                 PageRequest.of(page - 1, postPageSize, Sort.by(
                         Sort.Order.desc("likeCount"),
                         Sort.Order.desc("createdAt") ) ),
                 cafeteria, boardType);
+        int totalPages = userPage.getTotalPages() + 1;
+        int currentPage = userPage.getNumber() + 1;
         List<PostPreviewDTO> postPreviewDTOList = userPage.stream()
                 .map(post -> PostPreviewDTO.builder()
                         .id(post.getId())
@@ -98,8 +107,13 @@ public class PostService {
                         .build()
                 )
                 .collect(Collectors.toList());
+        PostPreviewListDTO postPreviewListDTO = PostPreviewListDTO.builder()
+                .currentPage(currentPage)
+                .totalPages(totalPages)
+                .postPreviewDTOList(postPreviewDTOList)
+                .build();
 
-        return postPreviewDTOList;
+        return postPreviewListDTO;
     }
 
 //    public List<PostPreviewDTO> getReportedPostList(Long cafeteriaId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5 

## 📝작업 내용

> 
1. 공지/메뉴 건의 게시물 API 응답 DTO에 현재 페이지, 전체 페이지 속성 추가
2. 위 API 서비스 메서드에서 Page 객체를 통해 위 정보 추가