### PR TITLE
[fix]: 알림 스케줄링 메서드 중복 실행 이슈 해결

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/common/RedisService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/common/RedisService.java
@@ -7,11 +7,26 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class RedisService {
     private final RedisTemplate<String, Object> redisTemplate;
+
+    public boolean tryLock(String key, String value, long timeout, TimeUnit unit) {
+        Boolean success = redisTemplate.opsForValue().setIfAbsent(key, value, timeout, unit);
+        return success != null && success;
+    }
+
+    public boolean unlock(String key, String value) {
+        String currentValue = (String) redisTemplate.opsForValue().get(key);
+        if (value.equals(currentValue)) {
+            redisTemplate.delete(key);
+            return true;
+        }
+        return false;
+    }
 
     public void setValue(String key, String value){
         ValueOperations<String, Object> values = redisTemplate.opsForValue();

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/common/RedisService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/common/RedisService.java
@@ -19,15 +19,6 @@ public class RedisService {
         return success != null && success;
     }
 
-    public boolean unlock(String key, String value) {
-        String currentValue = (String) redisTemplate.opsForValue().get(key);
-        if (value.equals(currentValue)) {
-            redisTemplate.delete(key);
-            return true;
-        }
-        return false;
-    }
-
     public void setValue(String key, String value){
         ValueOperations<String, Object> values = redisTemplate.opsForValue();
         values.set(key, value);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #101 

## 📝작업 내용

> 
1. redis를 이용하여 lock을 얻는 메서드 추가
2. 해당 메서드를 통해 스케줄링된 메서드에 lock을 얻는 부분 추가

빠른 lock 해제로 중복 알림이 발생할 가능성을 고려하여 명시적으로 해제하지 않음. 10초로 설정한 timeout되면 자동으로 해제됨
