### PR TITLE
[refactor]: 토큰 재발급 로직 변경

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/apiPayload/code/status/ErrorStatus.java
@@ -56,9 +56,8 @@ public enum ErrorStatus implements BaseCode {
     EMAIL_IS_NOT_SAME(HttpStatus.BAD_REQUEST, "LOGIN4006", "인증을 요청한 이메일과 검증을 요청한 이메일이 다릅니다."),
     EMAIL_SENDER_IS_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "LOGIN5001", "서버내의 이메일 sender가 정해지지 않았습니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "LOGIN4006", "입력한 패스워드가 올바르지 않습니다."),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "LOGIN4008", "액세스 토큰이 만료되었습니다. 토큰 재발급 요청을 해주세요."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "LOGIN4007", "리프레시 토큰이 만료되었습니다. 재인증이 필요합니다.");
-
-
 
 
 

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/controller/TokenController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/controller/TokenController.java
@@ -1,0 +1,42 @@
+package fiveguys.Tom.Cafeteria.Server.auth.controller;
+
+
+import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
+import fiveguys.Tom.Cafeteria.Server.apiPayload.code.status.ErrorStatus;
+import fiveguys.Tom.Cafeteria.Server.auth.jwt.JwtToken;
+import fiveguys.Tom.Cafeteria.Server.auth.jwt.service.JwtUtil;
+import fiveguys.Tom.Cafeteria.Server.domain.common.RedisService;
+import fiveguys.Tom.Cafeteria.Server.exception.GeneralException;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+    private final JwtUtil jwtUtil;
+    private final RedisService redisService;
+    @PostMapping("/token/access-token")
+    @Operation(summary = "토큰 재발급 API", description = "액세스 토큰의 리프레시를 가져와서" +
+            " 기간이 유효하면 재발급, 유효하지 않으면 실패 처리를 한다")
+    public ApiResponse<String> reissueTokens(HttpServletRequest request){
+        String accessToken = null;
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            accessToken = authHeader.substring(7);
+        }
+        String refreshToken = redisService.getValue(accessToken);
+        if(refreshToken == null){ //refreshToken 만료
+            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_EXPIRED);
+        }
+        String userId = redisService.getValue(refreshToken);
+        redisService.deleteValues(accessToken);
+        JwtToken newJwtToken = jwtUtil.generateToken(userId); // 토큰 재발급
+        redisService.deleteValues(refreshToken);
+        accessToken = newJwtToken.getAccessToken();
+        return ApiResponse.onSuccess(accessToken);
+    }
+
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtTokenProvider implements TokenProvider {
     }
 
     @Override
-    public Jws<Claims> verifyToken(String token) throws ExpiredJwtException{
+    public Jws<Claims> verifyToken(String token){
         try {
             Jws<Claims> claims = Jwts.parser()
                     .verifyWith(secretkey)
@@ -47,6 +47,10 @@ public class JwtTokenProvider implements TokenProvider {
             // 부적절한 인자가 전달된 경우의 처리
             log.info("부적절한 인자가 전달되었습니다.");
             throw new GeneralException(ErrorStatus.INVALID_TOKEN_ERROR);
+        } catch (ExpiredJwtException e){
+            // 토큰 기간 만료의 경우
+            log.info("토큰이 만료되었습니다.");
+            throw new GeneralException(ErrorStatus.ACCESS_TOKEN_EXPIRED);
         }
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtUtil.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtUtil.java
@@ -28,7 +28,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtUtil {
     private final UserQueryService userQueryService;
-    private static final Duration refreshTokenExpireDuration = Duration.ofDays(14);
+    private static final Duration refreshTokenExpireDuration = Duration.ofDays(360);
     private static final Duration accessTokenExpireDuration = Duration.ofDays(30); // 나중에 수정
     private final RedisService redisService;
     @Value("${spring.jwt.secret}")
@@ -45,7 +45,7 @@ public class JwtUtil {
         String refreshToken = generateRefreshToken(id);
         String accessToken = generateAccessToken(id);
         redisService.setValue(refreshToken, id, refreshTokenExpireDuration);
-        redisService.setValue(accessToken, refreshToken);
+        redisService.setValue(accessToken, refreshToken, refreshTokenExpireDuration);
         log.info("accessToken = {}", accessToken);
         return new JwtToken(accessToken, refreshToken);
     }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/config/WebConfig.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/config/WebConfig.java
@@ -3,10 +3,8 @@ package fiveguys.Tom.Cafeteria.Server.config;
 
 import fiveguys.Tom.Cafeteria.Server.auth.jwt.service.JwtTokenProvider;
 import fiveguys.Tom.Cafeteria.Server.auth.jwt.service.JwtUtil;
-import fiveguys.Tom.Cafeteria.Server.domain.common.RedisService;
 import fiveguys.Tom.Cafeteria.Server.filter.CorsFilter;
 import fiveguys.Tom.Cafeteria.Server.filter.JwtAuthFilter;
-import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -18,11 +16,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
     private final JwtUtil jwtUtil;
     private final JwtTokenProvider jwtTokenProvider;
-    private final RedisService redisService;
     @Bean
     public FilterRegistrationBean<JwtAuthFilter> jwtFilterRegistration() {
         FilterRegistrationBean<JwtAuthFilter> registration = new FilterRegistrationBean<>();
-        registration.setFilter(new JwtAuthFilter(jwtTokenProvider, jwtUtil, redisService)); // 필터 인스턴스 설정
+        registration.setFilter(new JwtAuthFilter(jwtTokenProvider, jwtUtil)); // 필터 인스턴스 설정
         registration.addUrlPatterns("/*");
         registration.setOrder(2); // 필터의 순서 설정. 값이 낮을수록 먼저 실행
         return registration;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #125 

## 📝작업 내용

> 
1. JWT 필터에 재발급 로직 제거
2. 토큰 재발급 API 추가
3. JwtFilter 및 WebConfig에 RedisService 종속성 제거
4. 액세스 토큰 휴효성 검사 실패 예외 추가
