### PR TITLE
[refactor]: 식단 조회 API 리팩토링

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtUtil.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/auth/jwt/service/JwtUtil.java
@@ -28,8 +28,8 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtUtil {
     private final UserQueryService userQueryService;
-    private static final Duration refreshTokenExpireDuration = Duration.ofSeconds(1);
-    private static final Duration accessTokenExpireDuration = Duration.ofSeconds(5); // 나중에 수정
+    private static final Duration refreshTokenExpireDuration = Duration.ofDays(365);
+    private static final Duration accessTokenExpireDuration = Duration.ofDays(60); // 나중에 수정
     private final RedisService redisService;
     @Value("${spring.jwt.secret}")
     private String secret;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
@@ -5,6 +5,8 @@ import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.service.CafeteriaQueryService;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.DietPhoto;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.repository.DietPhotoRepository;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietRequestDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
@@ -35,6 +37,7 @@ public class AdminDietController {
     private final DietQueryService dietQueryService;
     private final MenuQueryService menuQueryService;
     private final CafeteriaQueryService cafeteriaQueryService;
+    private final DietPhotoRepository dietPhotoRepository;
     @Value("${cloud.aws.s3.path.prefix}")
     private String prefixURI;
 
@@ -54,6 +57,7 @@ public class AdminDietController {
     @PutMapping("/menus")
     public ApiResponse<DietResponseDTO.DietQueryDTO> addMenu(@RequestBody DietRequestDTO.ChangeMenuDTO menuAddDTO){
         Diet diet = dietQueryService.getDiet(menuAddDTO.getCafeteriaId(), menuAddDTO.getLocalDate(), menuAddDTO.getMeals());
+        DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
         Menu menu = menuQueryService.findByCafeteriaAndName(menuAddDTO.getCafeteriaId(), menuAddDTO.getMenuName());
         Diet addedDiet = dietCommandService.addMenu(diet, menu);
 
@@ -62,13 +66,14 @@ public class AdminDietController {
                 .map(MenuDiet::getMenu)
                 .map(MenuConverter::toMenuQueryDTO)
                 .collect(Collectors.toList());
-        DietResponseDTO.DietQueryDTO dietQueryDTO = DietConverter.toDietResponseDTO(prefixURI, addedDiet, MenuConverter.toMenuResponseListDTO(menuList));
+        DietResponseDTO.DietQueryDTO dietQueryDTO = DietConverter.toDietResponseDTO(prefixURI, addedDiet, dietPhoto ,MenuConverter.toMenuResponseListDTO(menuList));
         return ApiResponse.onSuccess(dietQueryDTO);
     }
     @Operation(summary = "식단에 등록된 메뉴를 제거하는 API", description = "식단 id와 메뉴 이름을 받아 식단에 등록된 메뉴를 제거")
     @DeleteMapping("/menus")
     public ApiResponse<DietResponseDTO.DietQueryDTO> deleteMenu(@RequestBody DietRequestDTO.ChangeMenuDTO menuAddDTO){
         Diet diet = dietQueryService.getDiet(menuAddDTO.getCafeteriaId(), menuAddDTO.getLocalDate(), menuAddDTO.getMeals());
+        DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
         Menu menu = menuQueryService.findByCafeteriaAndName(menuAddDTO.getCafeteriaId(), menuAddDTO.getMenuName());
         Diet removedDiet = dietCommandService.removeMenu(diet, menu);
 
@@ -77,7 +82,7 @@ public class AdminDietController {
                 .map(MenuDiet::getMenu)
                 .map(MenuConverter::toMenuQueryDTO)
                 .collect(Collectors.toList());
-        DietResponseDTO.DietQueryDTO dietQueryDTO = DietConverter.toDietResponseDTO(prefixURI, removedDiet, MenuConverter.toMenuResponseListDTO(menuList));
+        DietResponseDTO.DietQueryDTO dietQueryDTO = DietConverter.toDietResponseDTO(prefixURI, removedDiet, dietPhoto, MenuConverter.toMenuResponseListDTO(menuList));
         return ApiResponse.onSuccess(dietQueryDTO);
     }
 

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
@@ -2,16 +2,13 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.controller;
 
 
 import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
-import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
-import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.repository.CafeteriaRepository;
-import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.service.CafeteriaQueryService;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
-import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietRequestDTO;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.DietPhoto;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.repository.DietPhotoRepository;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.MenuDiet;
-import fiveguys.Tom.Cafeteria.Server.domain.diet.repository.DietRepository;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.service.DietQueryService;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.converter.MenuConverter;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseDTO;
@@ -23,13 +20,14 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/diets")
 public class DietController {
     private final DietQueryService dietQueryService;
-    private final CafeteriaRepository cafeteriaRepository;
+    private final DietPhotoRepository dietPhotoRepository;
     @Value("${cloud.aws.s3.path.prefix}")
     private String prefixURI;
 
@@ -40,34 +38,43 @@ public class DietController {
                                                              @RequestParam(name = "localDate") LocalDate localDate,
                                                              @RequestParam(name = "meals") Meals meals){
         Diet diet = dietQueryService.getDiet(cafeteriaId,localDate, meals);
+        DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
         List<MenuDiet> menuDietList = diet.getMenuDietList();
         List<MenuResponseDTO.MenuQueryDTO> menuList = menuDietList.stream()
                 .map(MenuDiet::getMenu)
                 .map(MenuConverter::toMenuQueryDTO)
                 .collect(Collectors.toList());
-        DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, MenuConverter.toMenuResponseListDTO(menuList));
+        DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, dietPhoto ,MenuConverter.toMenuResponseListDTO(menuList));
         return ApiResponse.onSuccess(dietQueryResponseDTO);
     }
-    @Operation(summary = "식당의 금주의 식단표 API", description = "식당id, 년/월/주차, 식때를 받아서 그 주차의 메뉴 리스트를 반환한다.")
-    @GetMapping("/weeks")
-    public ApiResponse<DietResponseDTO.WeekDietsResponseDTO> getWeekDiets(@RequestParam(name = "cafeteriaId")Long cafeteriaId,
-                                                                          @RequestParam(name = "year") int year,
-                                                                          @RequestParam(name = "month") int month,
-                                                                          @RequestParam(name = "weekNum") int weekNum,
-                                                                          @RequestParam(name = "meals") Meals meals) {
-        Cafeteria cafeteria = cafeteriaRepository.getReferenceById(cafeteriaId);
-        List<Diet> dietListOfWeek = dietQueryService
-                .getDietListOfWeek(cafeteria, year, month, weekNum, meals);
-        List<DietResponseDTO.DietQueryDTO> dietResponseDTOs = dietListOfWeek.stream()
-                .map(diet -> {
-                    List<MenuDiet> menuDietList = diet.getMenuDietList();
-                    List<MenuResponseDTO.MenuQueryDTO> menuList = menuDietList.stream()
-                            .map(MenuDiet::getMenu)
-                            .map(MenuConverter::toMenuQueryDTO)
+    @Operation(summary =  "모든 식당의 3주치의 식단표 API", description = "식당id리스트, 시작년/월/주차, 기간을 입력 받아 메뉴 리스트를 반환한다.")
+    @GetMapping("/main")
+    public ApiResponse<DietResponseDTO.MainViewResponseDTO> getWeekDietsTable(@RequestParam(name = "cafeteriaIdList") List<Long> cafeteriaIdList) {
+        List<DietResponseDTO.ThreeWeeksDietsResponseDTO> threeWeeksDietsResponseDTOS = cafeteriaIdList.stream()
+                .map(id -> dietQueryService.getThreeWeeksDiet(id)) //각 식당 마다
+                .map(dietList -> {
+                    List<DietResponseDTO.DietQueryDTO> dietQueryDTOList = dietList.stream()
+                            .map(diet -> {//각 식단 마다
+                                DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
+                                List<MenuResponseDTO.MenuQueryDTO> menuQueryDTOList = diet.getMenuDietList().stream()
+                                        .map(MenuDiet::getMenu) //각 메뉴 마다
+                                        .map(MenuConverter::toMenuQueryDTO)
+                                        .collect(Collectors.toList());
+                                DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, dietPhoto, MenuConverter.toMenuResponseListDTO(menuQueryDTOList));
+                                return dietQueryResponseDTO;
+                            })
                             .collect(Collectors.toList());
-                    return DietConverter.toDietResponseDTO(prefixURI, diet, MenuConverter.toMenuResponseListDTO(menuList));
+                    return dietQueryDTOList;
                 })
+                .map(dietQueryDTOS -> DietConverter.toThreeWeeksDietsResponseDTO(dietQueryDTOS))
                 .collect(Collectors.toList());
-        return ApiResponse.onSuccess(DietConverter.toWeekDietsResponseDTO(dietResponseDTOs));
+
+        IntStream.range(0, threeWeeksDietsResponseDTOS.size()).forEach(i -> {
+            threeWeeksDietsResponseDTOS.get(i).setCafeteriaId(cafeteriaIdList.get(i));
+        });
+        DietResponseDTO.MainViewResponseDTO responseDTO = DietResponseDTO.MainViewResponseDTO.builder()
+                .threeWeeksDietsResponseDTOS(threeWeeksDietsResponseDTOS)
+                .build();
+        return ApiResponse.onSuccess(responseDTO);
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
@@ -1,12 +1,12 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.converter;
 
 
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.DietPhoto;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietRequestDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseDTO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,12 +24,12 @@ public class DietConverter {
         return diet;
     }
 
-    public static DietResponseDTO.DietQueryDTO toDietResponseDTO(String prefixURI, Diet diet, MenuResponseDTO.MenuResponseListDTO menuResponseListDTO){
+    public static DietResponseDTO.DietQueryDTO toDietResponseDTO(String prefixURI, Diet diet, DietPhoto dietPhoto, MenuResponseDTO.MenuResponseListDTO menuResponseListDTO){
 
         return DietResponseDTO.DietQueryDTO.builder()
                 .dietId(diet.getId())
                 .menuResponseListDTO(menuResponseListDTO)
-                .photoURI(diet.getDietPhoto() != null ? prefixURI + diet.getDietPhoto().getImageKey() : "사진이 등록되어있지 않습니다.")
+                .photoURI(dietPhoto != null ? prefixURI + dietPhoto.getImageKey() : "사진이 등록되어있지 않습니다.")
                 .dayOff(diet.isDayOff())
                 .soldOut(diet.isSoldOut())
                 .date(diet.getLocalDate())
@@ -43,9 +43,9 @@ public class DietConverter {
                 .build();
     }
 
-    public static DietResponseDTO.WeekDietsResponseDTO toWeekDietsResponseDTO(List<DietResponseDTO.DietQueryDTO> dietResponseDTOList){
-        return DietResponseDTO.WeekDietsResponseDTO.builder()
-                .dietResponseDTOList(dietResponseDTOList)
+    public static DietResponseDTO.ThreeWeeksDietsResponseDTO toThreeWeeksDietsResponseDTO(List<DietResponseDTO.DietQueryDTO> dietResponseDTOList){
+        return DietResponseDTO.ThreeWeeksDietsResponseDTO.builder()
+                .ThreeWeeksResponseDTO(dietResponseDTOList)
                 .build();
     }
     public static DietResponseDTO.SwitchSoldOutResponseDTO toSwitchSoldOutResponseDTO(boolean isSoldOut){

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dietPhoto/repository/DietPhotoRepository.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dietPhoto/repository/DietPhotoRepository.java
@@ -1,7 +1,9 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.repository;
 
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.DietPhoto;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DietPhotoRepository extends JpaRepository<DietPhoto, Long> {
+    public DietPhoto findByDiet(Diet diet);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dietPhoto/service/DietPhotoServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dietPhoto/service/DietPhotoServiceImpl.java
@@ -54,12 +54,11 @@ public class DietPhotoServiceImpl implements DietPhotoService{
     @Transactional
     public DietPhoto deleteDietPhoto(DietRequestDTO.DietQueryDTO dietQueryDTO) {
         Diet diet = dietQueryService.getDiet(dietQueryDTO.getCafeteriaId(), dietQueryDTO.getLocalDate(), dietQueryDTO.getMeals());
-        DietPhoto dietPhoto = diet.getDietPhoto();
+        DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
         deleteImage(dietPhoto.getImageKey());
         if(entityManager.contains(dietPhoto)){
             log.info("이건 영속성임");
         }
-        diet.clearDietPhoto();
         dietPhotoRepository.delete(dietPhoto);
 
         return dietPhoto;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietResponseDTO.java
@@ -2,10 +2,7 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.dto;
 
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.dto.MenuResponseDTO;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -39,8 +36,10 @@ public class DietResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    public static class WeekDietsResponseDTO {
-        private List<DietResponseDTO.DietQueryDTO> dietResponseDTOList;
+    @Setter
+    public static class ThreeWeeksDietsResponseDTO {
+        private Long cafeteriaId;
+        private List<DietResponseDTO.DietQueryDTO> ThreeWeeksResponseDTO;
     }
 
     @Builder
@@ -57,4 +56,13 @@ public class DietResponseDTO {
     public static class SwitchDayOffResponseDTO {
         private boolean isDayOff;
     }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MainViewResponseDTO{
+        List<ThreeWeeksDietsResponseDTO> threeWeeksDietsResponseDTOS;
+    }
+
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/Diet.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/Diet.java
@@ -2,26 +2,18 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.entity;
 
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
-import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.DietPhoto;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.Month;
-import java.time.temporal.TemporalAdjusters;
-import java.time.temporal.TemporalField;
-import java.time.temporal.WeekFields;
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
 @DynamicUpdate
 @Entity
 public class Diet extends BaseEntity {
@@ -36,23 +28,14 @@ public class Diet extends BaseEntity {
 
     private boolean dayOff;
 
-    private LocalDate localDate; // 나중에 과거의 식단까지 볼 수 있도록 확장하면 날짜로 수정할 예정
-
-    private int year;
-
-    private int month;
-
-    private int week;
+    private LocalDate localDate;
 
     @JoinColumn(name = "cafeteria_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Cafeteria cafeteria;
 
     @OneToMany(mappedBy = "diet", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<MenuDiet> menuDietList = new ArrayList<>();
-
-    @OneToOne(mappedBy = "diet", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private DietPhoto dietPhoto;
+    private List<MenuDiet> menuDietList;
 
     public void setCafeteria(Cafeteria cafeteria) {
         this.cafeteria = cafeteria;
@@ -73,46 +56,6 @@ public class Diet extends BaseEntity {
 
     public void switchDayOff(){
         this.dayOff = this.dayOff ? false : true;
-    }
-
-    public void setDateInfo(){
-        // 주의 시작을 월요일로 설정
-        WeekFields weekFields = WeekFields.of(DayOfWeek.MONDAY, 1);
-
-        // 월의 주차 정보를 가져오기 위한 TemporalField
-        TemporalField weekOfMonth = weekFields.weekOfMonth();
-
-        // 현재 주의 월요일 날짜를 구함
-        LocalDate monday = localDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        // 현재 주의 목요일 날짜를 구함
-        LocalDate thursday;
-        if( localDate.getDayOfWeek().getValue() <= DayOfWeek.THURSDAY.getValue()){
-            //월,화,수,목은 다음 목요일 날짜를
-            thursday = localDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.THURSDAY));
-        }
-        else{
-            // 금,토,일은 이전 목요일 날짜를
-            thursday = localDate.with(TemporalAdjusters.previous(DayOfWeek.THURSDAY));
-        }
-        // 월요일과 목요일이 같은 달에 속하지 않는 경우, 주차 계산을 위해 목요일을 사용
-        if (monday.getMonth() != thursday.getMonth()) {
-            // 목요일이 다음 달에 속하면, 그 주는 다음 달의 첫째 주로 간주
-            // 목요일의 주차 정보를 이용
-            this.week = thursday.get(weekOfMonth);
-            this.month = thursday.getMonthValue();
-            this.year = thursday.getYear();
-        } else {
-            // 그렇지 않으면, 월요일 기준의 주차 정보를 이용
-            this.week = monday.get(weekOfMonth);
-            this.month = monday.getMonthValue();
-            this.year = monday.getYear();
-        }
-
-        System.out.println(localDate + "는 " + thursday.getMonthValue() + "월의 " + this.week+ "주차 입니다.");
-    }
-
-    public void clearDietPhoto() {
-        this.dietPhoto = null;
     }
 
     public String getMenuListString(){

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepository.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepository.java
@@ -13,8 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DietRepository extends JpaRepository<Diet, Long> {
-    List<Diet> findByCafeteriaAndLocalDate(Cafeteria cafeteria, LocalDate localDate);
-
+    // 식단 단건 조회
     @Query("SELECT d FROM Diet d " +
             "LEFT JOIN FETCH d.menuDietList md " +
             "LEFT JOIN FETCH md.menu m " +
@@ -26,23 +25,5 @@ public interface DietRepository extends JpaRepository<Diet, Long> {
             @Param("localDate") LocalDate localDate,
             @Param("meals") Meals meals
     );
-    @Query("SELECT d FROM Diet d " +
-            "LEFT JOIN FETCH d.dietPhoto dp " +
-            "LEFT JOIN FETCH d.menuDietList md " +
-            "LEFT JOIN FETCH md.menu m " +
-            "WHERE d.cafeteria = :cafeteria " +
-            "AND d.year = :year " +
-            "AND d.month = :month " +
-            "AND d.week = :week " +
-            "AND d.meals = :meals "
-    )
-    List<Diet> findAllByCafeteriaAndYearAndMonthAndWeekAndMeals(
-            @Param("cafeteria") Cafeteria cafeteria,
-            @Param("year") int year,
-            @Param("month") int month,
-            @Param("week") int week,
-            @Param("meals") Meals meals
-    );
-
     boolean existsByCafeteriaAndLocalDateAndMeals(Cafeteria cafeteria, LocalDate date, Meals meals);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryCustom.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryCustom.java
@@ -4,5 +4,5 @@ import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import java.util.List;
 
 public interface DietRepositoryCustom {
-    List<Diet> findDietsByThreeWeeks();
+    List<Diet> findDietsByThreeWeeks(Long cafeteriaId);
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryCustom.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryCustom.java
@@ -1,0 +1,8 @@
+package fiveguys.Tom.Cafeteria.Server.domain.diet.repository;
+
+import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
+import java.util.List;
+
+public interface DietRepositoryCustom {
+    List<Diet> findDietsByThreeWeeks();
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryImpl.java
@@ -1,0 +1,49 @@
+package fiveguys.Tom.Cafeteria.Server.domain.diet.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.QDiet;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.querydsl.core.types.dsl.Expressions.numberTemplate;
+
+@Repository
+@Slf4j
+public class DietRepositoryImpl implements  DietRepositoryCustom{
+    private JPAQueryFactory queryFactory;
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @PostConstruct
+    public void init() {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<Diet> findDietsByThreeWeeks() {
+        QDiet qDiet = QDiet.diet;
+
+        // 현재 주차 계산 (주차 옵션 5)
+        NumberTemplate<Integer> currentWeek = numberTemplate(Integer.class, "WEEK(CURDATE())");
+
+        // 전주, 이번주, 다음주 주차 계산
+        NumberTemplate<Integer> entityWeek = numberTemplate(Integer.class, "WEEK({0})", qDiet.localDate);
+
+        // 조건 설정: 전주, 이번주, 다음주
+        BooleanExpression isWithinThreeWeeks = entityWeek.between(currentWeek.subtract(1), currentWeek.add(1));
+
+        List<Diet> dietList = queryFactory.selectFrom(qDiet)
+                .where(isWithinThreeWeeks)
+                .fetch();
+        log.info("result = {}", dietList);
+        return dietList;
+    }
+}

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietCommandServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietCommandServiceImpl.java
@@ -4,14 +4,11 @@ import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.service.CafeteriaQueryService;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietRequestDTO;
-import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
-import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.MenuDiet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.repository.MenuDietRepository;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.repository.DietRepository;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
-import fiveguys.Tom.Cafeteria.Server.domain.menu.service.MenuQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +32,6 @@ public class DietCommandServiceImpl implements DietCommandService{
         menuList.stream()
                 .forEach( (menu) ->MenuDiet.createMenuDiet(menu, diet));
         diet.setCafeteria(cafeteria);
-        diet.setDateInfo();
         Diet savedDiet = dietRepository.save(diet);
         return savedDiet;
     }
@@ -79,7 +75,6 @@ public class DietCommandServiceImpl implements DietCommandService{
                     .dayOff(true)
                     .soldOut(false)
                     .build();
-            createdDiet.setDateInfo();
             return dietRepository.save(createdDiet);
         }
         else{ //해당 식당과 시간에 식단이 있다면

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryService.java
@@ -4,17 +4,15 @@ import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 
 public interface DietQueryService {
 
-    public Diet getDiet(Long dietId);
     public Diet getDiet(Long cafeteriaId, LocalDate localDate, Meals meals);
 
     public boolean existsDiet(Long cafeteriaId, LocalDate localDate, Meals meals);
-    public List<Diet> getDietsOfDay(Cafeteria cafeteria, LocalDate localDate);
-    public List<Diet> getDietListOfWeek(Cafeteria cafeteria, int year, int month, int weekNum, Meals meals);
+
+    public List<Diet> getThreeWeeksDiet(Long cafeteriaId);
 
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietQueryServiceImpl.java
@@ -6,6 +6,7 @@ import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.repository.CafeteriaReposi
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Meals;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.repository.DietRepository;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.repository.DietRepositoryCustom;
 import fiveguys.Tom.Cafeteria.Server.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,12 +19,9 @@ import java.util.*;
 @RequiredArgsConstructor
 public class DietQueryServiceImpl implements DietQueryService{
     private final DietRepository dietRepository;
+    private final DietRepositoryCustom dietRepositoryCustom;
     private final CafeteriaRepository cafeteriaRepository;
 
-    @Override
-    public Diet getDiet(Long dietId) {
-        return dietRepository.findById(dietId).orElseThrow(()-> new GeneralException(ErrorStatus.DIET_NOT_FOUND));
-    }
 
     @Override
     public Diet getDiet(Long cafeteriaId, LocalDate localDate, Meals meals) {
@@ -40,16 +38,8 @@ public class DietQueryServiceImpl implements DietQueryService{
     }
 
     @Override
-    public List<Diet> getDietsOfDay(Cafeteria cafeteria, LocalDate localDate) {
-        return dietRepository.findByCafeteriaAndLocalDate(cafeteria, localDate);
+    public List<Diet> getThreeWeeksDiet(Long cafeteriaId) {
+        return dietRepositoryCustom.findDietsByThreeWeeks(cafeteriaId);
     }
 
-    @Override
-    public List<Diet> getDietListOfWeek(Cafeteria cafeteria, int year, int month, int weekNum, Meals meals) {
-        List<Diet> dietList = dietRepository
-                .findAllByCafeteriaAndYearAndMonthAndWeekAndMeals(cafeteria, year, month, weekNum, meals);
-        dietList.stream()
-                .sorted(Comparator.comparing(Diet::getLocalDate));
-        return dietList;
-    }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/Menu.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/Menu.java
@@ -24,8 +24,8 @@ public class Menu extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "cafeteria_id")
-
     private Cafeteria cafeteria;
+
     @JoinColumn(name = "menu_category_id")
     @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private MenuCategory menuCategory;


### PR DESCRIPTION
## #️⃣연관된 이슈

#127 

## 📝작업 내용

> 
1. DB 식단 조회 식당별로 전주, 현재 주, 다음 주 3주치 조회하도록 변경
2. Diet-DietPhoto 일대일 양방향 관계 에서 지연 로딩이 되지 않아 양방향 관계 삭제
3. 메인에서 항상 모든 식당에 대한 3주치 식단 정보를 조회하기 때문에 
식당 주차 별 식단 조회 API -> 3주치 모든 식당별 식단 조회 API 변경 (요청 횟수 9 -> 1 감소)
