### PR TITLE
[refactor]: 식단 조회 API 리팩토링

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/entity/Cafeteria.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/entity/Cafeteria.java
@@ -14,7 +14,6 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
 @Entity
 public class Cafeteria extends BaseEntity {
     @Id

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/entity/Cafeteria.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/cafeteria/entity/Cafeteria.java
@@ -40,7 +40,7 @@ public class Cafeteria extends BaseEntity {
     private LocalTime lunchEndTime; //중식 운영 시작 시간
 
     @OneToMany(mappedBy = "cafeteria", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<UserCafeteria> userCafeteriaList = new ArrayList<>();
+    private List<UserCafeteria> userCafeteriaList;
 
     public void setCongestion(Congestion congestion) {
         this.congestion = congestion;

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
@@ -60,7 +60,6 @@ public class AdminDietController {
     @PutMapping("/menus")
     public ApiResponse<DietResponseDTO.DietQueryDTO> addMenu(@RequestBody DietRequestDTO.ChangeMenuDTO menuAddDTO){
         Diet diet = dietQueryService.getDiet(menuAddDTO.getCafeteriaId(), menuAddDTO.getLocalDate(), menuAddDTO.getMeals());
-        DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
         Menu menu = menuQueryService.findByCafeteriaAndName(menuAddDTO.getCafeteriaId(), menuAddDTO.getMenuName());
         Diet addedDiet = dietCommandService.addMenu(diet, menu);
 
@@ -69,14 +68,13 @@ public class AdminDietController {
                 .map(MenuDiet::getMenu)
                 .map(MenuConverter::toMenuQueryDTO)
                 .collect(Collectors.toList());
-        DietResponseDTO.DietQueryDTO dietQueryDTO = DietConverter.toDietResponseDTO(prefixURI, addedDiet, dietPhoto ,MenuConverter.toMenuResponseListDTO(menuList));
+        DietResponseDTO.DietQueryDTO dietQueryDTO = DietConverter.toDietResponseDTO(prefixURI, addedDiet ,MenuConverter.toMenuResponseListDTO(menuList));
         return ApiResponse.onSuccess(dietQueryDTO);
     }
     @Operation(summary = "식단에 등록된 메뉴를 제거하는 API", description = "식단 id와 메뉴 이름을 받아 식단에 등록된 메뉴를 제거")
     @DeleteMapping("/menus")
     public ApiResponse<DietResponseDTO.DietQueryDTO> deleteMenu(@RequestBody DietRequestDTO.ChangeMenuDTO menuAddDTO){
         Diet diet = dietQueryService.getDiet(menuAddDTO.getCafeteriaId(), menuAddDTO.getLocalDate(), menuAddDTO.getMeals());
-        DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
         Menu menu = menuQueryService.findByCafeteriaAndName(menuAddDTO.getCafeteriaId(), menuAddDTO.getMenuName());
         Diet removedDiet = dietCommandService.removeMenu(diet, menu);
 
@@ -85,7 +83,7 @@ public class AdminDietController {
                 .map(MenuDiet::getMenu)
                 .map(MenuConverter::toMenuQueryDTO)
                 .collect(Collectors.toList());
-        DietResponseDTO.DietQueryDTO dietQueryDTO = DietConverter.toDietResponseDTO(prefixURI, removedDiet, dietPhoto, MenuConverter.toMenuResponseListDTO(menuList));
+        DietResponseDTO.DietQueryDTO dietQueryDTO = DietConverter.toDietResponseDTO(prefixURI, removedDiet, MenuConverter.toMenuResponseListDTO(menuList));
         return ApiResponse.onSuccess(dietQueryDTO);
     }
 

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/AdminDietController.java
@@ -48,9 +48,12 @@ public class AdminDietController {
         List<Menu> menuList = menuNameList.stream()
                 .map(menuName -> menuQueryService.findByCafeteriaAndName(dietCreateDTO.getCafeteriaId() ,menuName))
                 .collect(Collectors.toList());
-        Cafeteria cafeteria = cafeteriaQueryService.findById(dietCreateDTO.getCafeteriaId());
-        Diet diet = dietCommandService.createDiet(cafeteria, dietCreateDTO, menuList);
-        return ApiResponse.onSuccess(DietConverter.toDietCreateResponseDTO(diet));
+        Diet diet = dietCommandService.createDiet(dietCreateDTO.getCafeteriaId(), dietCreateDTO, menuList);
+        List<String> enrroledMenuNameList = diet.getMenuDietList().stream()
+                .map(menuDiet -> menuDiet.getMenu().getName())
+                .collect(Collectors.toList());
+
+        return ApiResponse.onSuccess(DietConverter.toDietCreateResponseDTO(diet, enrroledMenuNameList));
     }
 
     @Operation(summary = "식단에 메뉴를 추가하는 API", description = "식단 id와 메뉴 이름을 받아 식단에 메뉴를 추가")

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
@@ -47,34 +47,22 @@ public class DietController {
         DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, dietPhoto ,MenuConverter.toMenuResponseListDTO(menuList));
         return ApiResponse.onSuccess(dietQueryResponseDTO);
     }
-    @Operation(summary =  "모든 식당의 3주치의 식단표 API", description = "식당id리스트, 시작년/월/주차, 기간을 입력 받아 메뉴 리스트를 반환한다.")
+    @Operation(summary =  "특정 식당의 3주치의 식단표 조회 API", description = "식당id를 입력 받아 해당 식당의 3주치의 식단 정보 리스트를 반환한다. 날짜순 오름차순으로 반환한다.")
     @GetMapping("/main")
-    public ApiResponse<DietResponseDTO.MainViewResponseDTO> getWeekDietsTable(@RequestParam(name = "cafeteriaIdList") List<Long> cafeteriaIdList) {
-        List<DietResponseDTO.ThreeWeeksDietsResponseDTO> threeWeeksDietsResponseDTOS = cafeteriaIdList.stream()
-                .map(id -> dietQueryService.getThreeWeeksDiet(id)) //각 식당 마다
-                .map(dietList -> {
-                    List<DietResponseDTO.DietQueryDTO> dietQueryDTOList = dietList.stream()
-                            .map(diet -> {//각 식단 마다
-                                DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
-                                List<MenuResponseDTO.MenuQueryDTO> menuQueryDTOList = diet.getMenuDietList().stream()
-                                        .map(MenuDiet::getMenu) //각 메뉴 마다
-                                        .map(MenuConverter::toMenuQueryDTO)
-                                        .collect(Collectors.toList());
-                                DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, dietPhoto, MenuConverter.toMenuResponseListDTO(menuQueryDTOList));
-                                return dietQueryResponseDTO;
-                            })
+    public ApiResponse<List<DietResponseDTO.DietQueryDTO>> getWeekDietsTable(@RequestParam(name = "cafeteriaId") Long cafeteriaId) {
+        // 식당 id 조건으로 해서 3주치 식단 정보 가져오기
+        List<Diet> threeWeeksDiet = dietQueryService.getThreeWeeksDiet(cafeteriaId);
+        List<DietResponseDTO.DietQueryDTO> dietQueryDTOList = threeWeeksDiet.stream() // diet와 연관된 dietphoto, dietMenu 가져오기
+                .map(diet -> {
+                    DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
+                    List<MenuResponseDTO.MenuQueryDTO> menuQueryDTOList = diet.getMenuDietList().stream()
+                            .map(MenuDiet::getMenu)
+                            .map(MenuConverter::toMenuQueryDTO)
                             .collect(Collectors.toList());
-                    return dietQueryDTOList;
+                    DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, dietPhoto, MenuConverter.toMenuResponseListDTO(menuQueryDTOList));
+                    return dietQueryResponseDTO;
                 })
-                .map(dietQueryDTOS -> DietConverter.toThreeWeeksDietsResponseDTO(dietQueryDTOS))
                 .collect(Collectors.toList());
-
-        IntStream.range(0, threeWeeksDietsResponseDTOS.size()).forEach(i -> {
-            threeWeeksDietsResponseDTOS.get(i).setCafeteriaId(cafeteriaIdList.get(i));
-        });
-        DietResponseDTO.MainViewResponseDTO responseDTO = DietResponseDTO.MainViewResponseDTO.builder()
-                .threeWeeksDietsResponseDTOS(threeWeeksDietsResponseDTOS)
-                .build();
-        return ApiResponse.onSuccess(responseDTO);
+        return ApiResponse.onSuccess(dietQueryDTOList);
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/controller/DietController.java
@@ -3,7 +3,6 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.controller;
 
 import fiveguys.Tom.Cafeteria.Server.apiPayload.ApiResponse;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
-import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.DietPhoto;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.repository.DietPhotoRepository;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietResponseDTO;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
@@ -38,13 +37,12 @@ public class DietController {
                                                              @RequestParam(name = "localDate") LocalDate localDate,
                                                              @RequestParam(name = "meals") Meals meals){
         Diet diet = dietQueryService.getDiet(cafeteriaId,localDate, meals);
-        DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
         List<MenuDiet> menuDietList = diet.getMenuDietList();
         List<MenuResponseDTO.MenuQueryDTO> menuList = menuDietList.stream()
                 .map(MenuDiet::getMenu)
                 .map(MenuConverter::toMenuQueryDTO)
                 .collect(Collectors.toList());
-        DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, dietPhoto ,MenuConverter.toMenuResponseListDTO(menuList));
+        DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, MenuConverter.toMenuResponseListDTO(menuList));
         return ApiResponse.onSuccess(dietQueryResponseDTO);
     }
     @Operation(summary =  "특정 식당의 3주치의 식단표 조회 API", description = "식당id를 입력 받아 해당 식당의 3주치의 식단 정보 리스트를 반환한다. 날짜순 오름차순으로 반환한다.")
@@ -54,12 +52,11 @@ public class DietController {
         List<Diet> threeWeeksDiet = dietQueryService.getThreeWeeksDiet(cafeteriaId);
         List<DietResponseDTO.DietQueryDTO> dietQueryDTOList = threeWeeksDiet.stream() // diet와 연관된 dietphoto, dietMenu 가져오기
                 .map(diet -> {
-                    DietPhoto dietPhoto = dietPhotoRepository.findByDiet(diet);
                     List<MenuResponseDTO.MenuQueryDTO> menuQueryDTOList = diet.getMenuDietList().stream()
                             .map(MenuDiet::getMenu)
                             .map(MenuConverter::toMenuQueryDTO)
                             .collect(Collectors.toList());
-                    DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, dietPhoto, MenuConverter.toMenuResponseListDTO(menuQueryDTOList));
+                    DietResponseDTO.DietQueryDTO dietQueryResponseDTO = DietConverter.toDietResponseDTO(prefixURI, diet, MenuConverter.toMenuResponseListDTO(menuQueryDTOList));
                     return dietQueryResponseDTO;
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
@@ -24,12 +24,12 @@ public class DietConverter {
         return diet;
     }
 
-    public static DietResponseDTO.DietQueryDTO toDietResponseDTO(String prefixURI, Diet diet, DietPhoto dietPhoto, MenuResponseDTO.MenuResponseListDTO menuResponseListDTO){
+    public static DietResponseDTO.DietQueryDTO toDietResponseDTO(String prefixURI, Diet diet, MenuResponseDTO.MenuResponseListDTO menuResponseListDTO){
 
         return DietResponseDTO.DietQueryDTO.builder()
                 .dietId(diet.getId())
                 .menuResponseListDTO(menuResponseListDTO)
-                .photoURI(dietPhoto != null ? prefixURI + dietPhoto.getImageKey() : "사진이 등록되어있지 않습니다.")
+                .photoURI(diet.getDietPhoto() != null ? prefixURI + diet.getDietPhoto().getImageKey() : "사진이 등록되어있지 않습니다.")
                 .dayOff(diet.isDayOff())
                 .soldOut(diet.isSoldOut())
                 .date(diet.getLocalDate())

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/converter/DietConverter.java
@@ -33,10 +33,12 @@ public class DietConverter {
                 .dayOff(diet.isDayOff())
                 .soldOut(diet.isSoldOut())
                 .date(diet.getLocalDate())
+                .meals(diet.getMeals())
                 .build();
     }
-    public static DietResponseDTO.DietCreateDTO toDietCreateResponseDTO(Diet diet){
+    public static DietResponseDTO.DietCreateDTO toDietCreateResponseDTO(Diet diet, List<String> enrolledMenuList){
         return DietResponseDTO.DietCreateDTO.builder()
+                .menuNameList(enrolledMenuList)
                 .cafeteriaId(diet.getCafeteria().getId())
                 .date(diet.getLocalDate())
                 .meals(diet.getMeals())

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietResponseDTO.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/dto/DietResponseDTO.java
@@ -31,6 +31,7 @@ public class DietResponseDTO {
         private MenuResponseDTO.MenuResponseListDTO menuResponseListDTO;
         private boolean soldOut;
         private boolean dayOff;
+        private Meals meals;
     }
     @Builder
     @AllArgsConstructor

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/Diet.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/entity/Diet.java
@@ -2,6 +2,7 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.entity;
 
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
 import fiveguys.Tom.Cafeteria.Server.domain.common.BaseEntity;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.DietPhoto;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 import jakarta.persistence.*;
 import lombok.*;
@@ -37,6 +38,8 @@ public class Diet extends BaseEntity {
     @OneToMany(mappedBy = "diet", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<MenuDiet> menuDietList;
 
+    @OneToOne(mappedBy = "diet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private DietPhoto dietPhoto;
     public void setCafeteria(Cafeteria cafeteria) {
         this.cafeteria = cafeteria;
     }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryImpl.java
@@ -3,6 +3,7 @@ package fiveguys.Tom.Cafeteria.Server.domain.diet.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import fiveguys.Tom.Cafeteria.Server.domain.diet.dietPhoto.entity.QDietPhoto;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.Diet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.QDiet;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.entity.QMenuDiet;
@@ -34,6 +35,7 @@ public class DietRepositoryImpl implements DietRepositoryCustom{
     public List<Diet> findDietsByThreeWeeks(Long cafeteriaId) {
         QDiet qDiet = QDiet.diet;
         QMenu qMenu = QMenu.menu;
+        QDietPhoto qDietPhoto = QDietPhoto.dietPhoto;
         QMenuDiet qMenuDiet = QMenuDiet.menuDiet;
 
         // 현재 주차 계산 (주차 옵션 5)
@@ -46,6 +48,8 @@ public class DietRepositoryImpl implements DietRepositoryCustom{
         BooleanExpression isWithinThreeWeeks = entityWeek.between(currentWeek.subtract(1), currentWeek.add(1));
 
         List<Diet> dietList = queryFactory.selectFrom(qDiet)
+                .leftJoin(qDiet.dietPhoto, qDietPhoto)
+                .fetchJoin()
                 .leftJoin(qDiet.menuDietList, qMenuDiet)
                 .fetchJoin()
                 .leftJoin(qMenuDiet.menu, qMenu)

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/repository/DietRepositoryImpl.java
@@ -12,7 +12,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
-
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import static com.querydsl.core.types.dsl.Expressions.numberTemplate;
@@ -45,14 +46,15 @@ public class DietRepositoryImpl implements DietRepositoryCustom{
         BooleanExpression isWithinThreeWeeks = entityWeek.between(currentWeek.subtract(1), currentWeek.add(1));
 
         List<Diet> dietList = queryFactory.selectFrom(qDiet)
-                .join(qDiet.menuDietList, qMenuDiet)
+                .leftJoin(qDiet.menuDietList, qMenuDiet)
                 .fetchJoin()
-                .join(qMenuDiet.menu, qMenu)
+                .leftJoin(qMenuDiet.menu, qMenu)
                 .fetchJoin()
                 .where(isWithinThreeWeeks
                         .and(qDiet.cafeteria.id.eq(cafeteriaId))
                 )
                 .fetch();
+        Collections.sort(dietList, Comparator.comparing(Diet::getLocalDate));
         return dietList;
     }
 }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietCommandService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietCommandService.java
@@ -9,7 +9,7 @@ import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 import java.util.List;
 
 public interface DietCommandService {
-    public Diet createDiet(Cafeteria cafeteria, DietRequestDTO.DietCreateDTO dietCreateDTO, List<Menu> menuList);
+    public Diet createDiet(Long cafeteriaId, DietRequestDTO.DietCreateDTO dietCreateDTO, List<Menu> menuList);
 
     public Diet addMenu(Diet diet, Menu menu);
 

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietCommandServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/diet/service/DietCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server.domain.diet.service;
 
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.repository.CafeteriaRepository;
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.service.CafeteriaQueryService;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.converter.DietConverter;
 import fiveguys.Tom.Cafeteria.Server.domain.diet.dto.DietRequestDTO;
@@ -19,16 +20,18 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class DietCommandServiceImpl implements DietCommandService{
     private final DietRepository dietRepository;
     private final CafeteriaQueryService cafeteriaQueryService;
+    private final CafeteriaRepository cafeteriaRepository;
     private final DietQueryService dietQueryService;
     private final MenuDietRepository menuDietRepository;
 
     @Override
-    public Diet createDiet(Cafeteria cafeteria, DietRequestDTO.DietCreateDTO dietCreateDTO, List<Menu> menuList) {
+    @Transactional
+    public Diet createDiet(Long cafeteriaId, DietRequestDTO.DietCreateDTO dietCreateDTO, List<Menu> menuList) {
         Diet diet = DietConverter.toDiet(dietCreateDTO);
+        Cafeteria cafeteria = cafeteriaRepository.getReferenceById(cafeteriaId);
         menuList.stream()
                 .forEach( (menu) ->MenuDiet.createMenuDiet(menu, diet));
         diet.setCafeteria(cafeteria);

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/Menu.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/entity/Menu.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
 @Entity
 public class Menu extends BaseEntity {
     @Id

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/service/MenuQueryServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/menu/service/MenuQueryServiceImpl.java
@@ -2,7 +2,7 @@ package fiveguys.Tom.Cafeteria.Server.domain.menu.service;
 
 import fiveguys.Tom.Cafeteria.Server.apiPayload.code.status.ErrorStatus;
 import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.entity.Cafeteria;
-import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.service.CafeteriaQueryService;
+import fiveguys.Tom.Cafeteria.Server.domain.cafeteria.repository.CafeteriaRepository;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.entity.Menu;
 import fiveguys.Tom.Cafeteria.Server.domain.menu.repository.MenuRepository;
 import fiveguys.Tom.Cafeteria.Server.exception.GeneralException;
@@ -16,7 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MenuQueryServiceImpl implements MenuQueryService{
     private final MenuRepository menuRepository;
-    private final CafeteriaQueryService cafeteriaQueryService;
+    private final CafeteriaRepository cafeteriaRepository;
     @Override
     public Menu findById(Long id) {
         Menu menu = menuRepository.findById(id).orElseThrow(
@@ -32,7 +32,7 @@ public class MenuQueryServiceImpl implements MenuQueryService{
 
     @Override
     public Menu findByCafeteriaAndName(Long cafeteriaId, String name) {
-        Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
+        Cafeteria cafeteria = cafeteriaRepository.getReferenceById(cafeteriaId);
         Menu menu = menuRepository.findByCafeteriaAndName(cafeteria, name).orElseThrow(
                 () -> new GeneralException(ErrorStatus.MENU_NOT_FOUND)
         );
@@ -41,7 +41,7 @@ public class MenuQueryServiceImpl implements MenuQueryService{
 
     @Override
     public boolean existByNameAndCafeteria(Long cafeteriaId, String name) {
-        Cafeteria cafeteria = cafeteriaQueryService.findById(cafeteriaId);
+        Cafeteria cafeteria = cafeteriaRepository.getReferenceById(cafeteriaId);
         return menuRepository.existsByCafeteriaAndName(cafeteria, name);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#127 

## 📝작업 내용

1. 식단 등록 시 식단에 등록된 메뉴리스트 제대로 반환하도록 수정
2. 받아온 식당 리스트 3주치 식단 정보 조회 API -> 특정 식당 3주치 식단 정보 조회 API로 변경 (관리자 페이지에서 식당별로 조회하기 때문에)
3. 엔티티 @ToString 제거
4. where문 조건으로 엔티티 필요할 시 프록시 객체 사용하도록 변경
5. diet와 dietphoto 양방향 관계 재설정 (주차별 식단에도 사진 조회 기능 추가하기로 함)
6. 3주치 식단 조회 쿼리 모든 식단에 대한 정보가 있어야 하기 때문에 left join으로 수정 
