### PR TITLE
[fix]: 알림 버그 수정

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMService.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMService.java
@@ -10,8 +10,7 @@ import java.util.List;
 
 public interface FCMService {
     public void sendMessage(Message message);
-    public void sendMessage(MulticastMessage message);
-    public MulticastMessage createMultiCastMessage(String title, String content);
+    public void sendMessage(MulticastMessage message, List<String> filteredTokens);
 
     public MulticastMessage createMultiCastMessage(String title, String content, List<String> tokenList);
 

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMServiceImpl.java
@@ -29,7 +29,7 @@ public class FCMServiceImpl implements FCMService{
         try {
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("response = {}", response);
-        } catch (FirebaseMessagingException e) {
+        } catch (FirebaseMessagingException e) { // 보내지 못했을 때 예외 처리 생각하기
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMServiceImpl.java
@@ -29,7 +29,7 @@ public class FCMServiceImpl implements FCMService{
         try {
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("response = {}", response);
-        } catch (FirebaseMessagingException e) { // 보내지 못했을 때 예외 처리 생각하기
+        } catch (FirebaseMessagingException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/FCMServiceImpl.java
@@ -4,7 +4,6 @@ import com.google.firebase.messaging.*;
 import fiveguys.Tom.Cafeteria.Server.apiPayload.code.status.ErrorStatus;
 import fiveguys.Tom.Cafeteria.Server.domain.notification.entity.AppNotification;
 import fiveguys.Tom.Cafeteria.Server.domain.notification.repository.AppNotificationRepository;
-import fiveguys.Tom.Cafeteria.Server.domain.user.entity.NotificationSet;
 import fiveguys.Tom.Cafeteria.Server.domain.user.repository.NotificationSetRepository;
 import fiveguys.Tom.Cafeteria.Server.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -14,15 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class FCMServiceImpl implements FCMService{
     private final AppNotificationRepository notificationRepository;
-    private final NotificationSetRepository notificationSetRepository;
 
     @Override
     public void sendMessage(Message message) {
@@ -35,45 +31,25 @@ public class FCMServiceImpl implements FCMService{
     }
 
     @Override
-    public void sendMessage(MulticastMessage message) {
+    public void sendMessage(MulticastMessage message, List<String> filteredTokens) {
         BatchResponse response = null;
         try {
-            response = FirebaseMessaging.getInstance().sendMulticast(message);
+            response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+            ArrayList<String> failedTokens = null;
+            if (response.getFailureCount() > 0) {
+                List<SendResponse> responses = response.getResponses();
+                failedTokens = new ArrayList<>();
+                for (int i = 0; i < responses.size(); i++) {
+                    if (!responses.get(i).isSuccessful()) {
+                        // The order of responses corresponds to the order of the registration tokens.
+                        failedTokens.add(filteredTokens.get(i));
+                    }
+                }
+            }
+            System.out.println("List of tokens that caused failures: " + failedTokens);
         } catch (FirebaseMessagingException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
         }
-        System.out.println(response.getSuccessCount() + " messages were sent successfully");
-    }
-
-    @Override
-    public MulticastMessage createMultiCastMessage(String title, String content) {
-        List<NotificationSet> notificationSetList = notificationSetRepository.findAll();
-        List<String> tokenList = notificationSetList.stream()
-                .map(notificationSet -> notificationSet.getRegistrationToken())
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-        AndroidConfig androidConfig = AndroidConfig.builder()
-                .setNotification(
-                        AndroidNotification.builder()
-                                .setColor("#ffffff")
-                                .build())
-                .build();
-//        ApnsConfig.builder()
-//                .setAps(Aps.builder()
-//                        .)
-        Notification notification = Notification.builder()
-                .setTitle(title)
-                .setBody(content)
-                .build();
-
-        if (tokenList == null || tokenList.isEmpty()) {
-            throw new GeneralException(ErrorStatus.REGISTRATION_TOKEN_EMPTY);
-        }
-        return MulticastMessage.builder()
-                .setNotification(notification)
-                .setAndroidConfig(androidConfig)
-                .addAllTokens(tokenList)
-                .build();
     }
 
     @Override

--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/domain/notification/service/NotificationServiceImpl.java
@@ -42,10 +42,16 @@ public class NotificationServiceImpl implements NotificationService{
     @Override
     public void sendAll(NotificationRequestDTO.SendAllDTO dto) {
         AppNotification notification = fcmService.storeNotification(dto.getTitle(), dto.getContent());
-        MulticastMessage multicastMessage = fcmService.createMultiCastMessage(dto.getTitle(), dto.getContent());
-        fcmService.sendMessage(multicastMessage);
 
         List<User> userList = userQueryService.getUsersAgreedNotification();
+        List<String> tokenList = userList.stream()
+                .map(User::getNotificationSet)
+                .map(NotificationSet::getRegistrationToken)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        MulticastMessage multicastMessage = fcmService.createMultiCastMessage(dto.getTitle(), dto.getContent(), tokenList);
+        fcmService.sendMessage(multicastMessage, tokenList);
+
         userList.stream()
                 .forEach(user -> {
                     UserAppNotification userAppNotification = UserAppNotification.createUserAppNotification(user, notification);
@@ -64,9 +70,8 @@ public class NotificationServiceImpl implements NotificationService{
                 .map(NotificationSet::getRegistrationToken)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
-        // multicast로 변경 예정
         MulticastMessage multiCastMessage = fcmService.createMultiCastMessage(dto.getTitle(), dto.getContent(), tokenList);
-        fcmService.sendMessage(multiCastMessage);
+        fcmService.sendMessage(multiCastMessage, tokenList);
 
         // 각 유저의 알림 저장
         userList.stream()
@@ -140,7 +145,7 @@ public class NotificationServiceImpl implements NotificationService{
                 .collect(Collectors.toList());
         try{
             MulticastMessage multiCastMessage = fcmService.createMultiCastMessage(notification.getTitle(), notification.getContent(), tokenList);
-            fcmService.sendMessage(multiCastMessage);
+            fcmService.sendMessage(multiCastMessage, tokenList);
         }
         catch (GeneralException e){
             return;
@@ -176,7 +181,7 @@ public class NotificationServiceImpl implements NotificationService{
 
         try{
             MulticastMessage multiCastMessage = fcmService.createMultiCastMessage(notification.getTitle(), notification.getContent(), tokenList);
-            fcmService.sendMessage(multiCastMessage);
+            fcmService.sendMessage(multiCastMessage, tokenList);
         }
         catch (GeneralException e){
             return;
@@ -230,7 +235,7 @@ public class NotificationServiceImpl implements NotificationService{
 
             try{
                 MulticastMessage multiCastMessage = fcmService.createMultiCastMessage(notification.getTitle(), notification.getContent(), tokenList);
-                fcmService.sendMessage(multiCastMessage);
+                fcmService.sendMessage(multiCastMessage, tokenList);
             }
             catch (GeneralException e){
                 return;
@@ -288,7 +293,7 @@ public class NotificationServiceImpl implements NotificationService{
                 .map(admin -> admin.getNotificationSet().getRegistrationToken())
                 .collect(Collectors.toList());
         MulticastMessage multiCastMessage = fcmService.createMultiCastMessage(dto.getTitle(), dto.getContent(), tokenList);
-        fcmService.sendMessage(multiCastMessage);
+        fcmService.sendMessage(multiCastMessage, tokenList);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#134

## 📝작업 내용

알림이 제대로 저장되지 않는 버그 찾아 수정
원인은 기존의 send 메서드가 deprecated되어 제대로 send하지 못해 트랜잭션에 같이 묶여있는 저장하는 작업이 취소 됐던 것
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 메서드 교체
2. Multicast 전송 실패 시에 실패한 토큰만 따로 볼 수 있도록 구조 개선
