### PR TITLE
refactor: JVM 시간대 UTC +9로 설정

### DIFF
--- a/src/main/java/fiveguys/Tom/Cafeteria/Server/TomCafeteriaServerApplication.java
+++ b/src/main/java/fiveguys/Tom/Cafeteria/Server/TomCafeteriaServerApplication.java
@@ -1,6 +1,7 @@
 package fiveguys.Tom.Cafeteria.Server;
 
 import fiveguys.Tom.Cafeteria.Server.auth.feignClient.config.FeignConfig;
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -10,6 +11,8 @@ import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import java.util.TimeZone;
+
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableFeignClients(defaultConfiguration = FeignConfig.class)
 @EnableJpaAuditing
@@ -17,6 +20,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 // 수동으로 FeignAutoConfiguration 가져오기
 @ImportAutoConfiguration({FeignAutoConfiguration.class})
 public class TomCafeteriaServerApplication {
+	@PostConstruct
+	public void init() {
+		// JVM 기본 시간대를 설정합니다.
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(TomCafeteriaServerApplication.class, args);


### PR DESCRIPTION
## #️⃣연관된 이슈

x

## 📝작업 내용

>
1. JVM 시간대 Asia/Seoul로 변경
